### PR TITLE
refactor: Refactor access to required settings

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,10 +1,10 @@
 version: 1
 send_anonymous_usage_stats: true
-project_id: "tap-iceberg"
+project_id: tap-iceberg
 plugins:
   extractors:
-  - name: "tap-iceberg"
-    namespace: "tap_iceberg"
+  - name: tap-iceberg
+    namespace: tap_iceberg
     pip_url: -e .
     capabilities:
     - state
@@ -19,9 +19,6 @@ plugins:
     - description: The type of catalog to connect to.
       label: Catalog Type
       name: catalog_type
-    - description: The URI of the catalog to connect to.
-      label: Catalog URI
-      name: catalog_uri
     - description: Additional properties to pass to the catalog connection.
       label: Catalog Properties
       name: catalog_properties

--- a/plugins/loaders/target-jsonl--andyh1203.lock
+++ b/plugins/loaders/target-jsonl--andyh1203.lock
@@ -1,0 +1,34 @@
+{
+  "plugin_type": "loaders",
+  "name": "target-jsonl",
+  "namespace": "target_jsonl",
+  "variant": "andyh1203",
+  "label": "JSON Lines (JSONL)",
+  "docs": "https://hub.meltano.com/loaders/target-jsonl--andyh1203",
+  "repo": "https://github.com/andyh1203/target-jsonl",
+  "pip_url": "target-jsonl",
+  "description": "JSONL loader",
+  "logo_url": "https://hub.meltano.com/assets/logos/loaders/jsonl.png",
+  "settings": [
+    {
+      "name": "destination_path",
+      "kind": "string",
+      "value": "output",
+      "label": "Destination Path",
+      "description": "Sets the destination path the JSONL files are written to, relative\nto the project root.\n\nThe directory needs to exist already, it will not be created\nautomatically.\n\nTo write JSONL files to the project root, set an empty string (`\"\"`).\n"
+    },
+    {
+      "name": "do_timestamp_file",
+      "kind": "boolean",
+      "value": false,
+      "label": "Include Timestamp in File Names",
+      "description": "Specifies if the files should get timestamped.\n\nBy default, the resulting file will not have a timestamp in the file name (i.e. `exchange_rate.jsonl`).\n\nIf this option gets set to `true`, the resulting file will have a timestamp associated with it (i.e. `exchange_rate-{timestamp}.jsonl`).\n"
+    },
+    {
+      "name": "custom_name",
+      "kind": "string",
+      "label": "Custom File Name Override",
+      "description": "Specifies a custom name for the filename, instead of the stream name.\n\nThe file name will be `{custom_name}-{timestamp}.jsonl`, if `do_timestamp_file` is `true`.\nOtherwise the file name will be `{custom_name}.jsonl`.\n\nIf custom name is not provided, the stream name will be used.\n"
+    }
+  ]
+}

--- a/tap_iceberg/tap.py
+++ b/tap_iceberg/tap.py
@@ -105,11 +105,7 @@ class TapIceberg(Tap):
     def _get_catalog(self) -> Catalog:
         """Load and return the Iceberg catalog based on the configuration."""
         catalog_properties = self.config.get("catalog_properties", {})
-        catalog_properties.update(
-            {
-                "type": self.config["catalog_type"],
-            }
-        )
+        catalog_properties["type"] = self.config["catalog_type"]
 
         # Export AWS credentials to the catalog properties, and standard AWS
         # environment variables to override any system credentials.
@@ -159,7 +155,7 @@ class TapIceberg(Tap):
         )
 
         return load_catalog(
-            self.config.get("catalog_name"),
+            self.config["catalog_name"],
             **{
                 key: value
                 for key, value in catalog_properties.items()


### PR DESCRIPTION
Settings `catalog_name` and `catalog_type` are required, so we use square bracket access for them.

In this PR I also made some changes to make the local `meltano.yml` work:

- Ran `meltano lock --update --all` and committed the resulting plugin lock file
- Removed redundant quotes
- Removed unused `catalog_uri` setting

Thanks!