### PR TITLE
Fix json schema normalization issue

### DIFF
--- a/tap_iceberg/map_json.py
+++ b/tap_iceberg/map_json.py
@@ -1,0 +1,73 @@
+"""Normalize PyArrow / Iceberg map values to JSON-compatible objects."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+
+def _jsonify_plain(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+def normalize_pyarrow_map_for_json(value: Any) -> Any:
+    """Convert PyArrow map representations to JSON objects (string keys).
+
+    ``Table.to_pylist()`` often emits map columns as a list of ``(key, value)``
+    pairs, while our Singer schema declares maps as JSON objects.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return {str(k): _jsonify_mapped_value(v) for k, v in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        entries = list(value)
+        if not entries:
+            return {}
+        probe = entries[0]
+        if isinstance(probe, Mapping) and "key" in probe and "value" in probe:
+            return {
+                str(row["key"]): _jsonify_mapped_value(row["value"])
+                for row in entries
+            }
+        if (
+            isinstance(probe, Sequence)
+            and not isinstance(probe, (str, bytes, bytearray))
+            and len(probe) == 2
+        ):
+            return {
+                str(pair[0]): _jsonify_mapped_value(pair[1]) for pair in entries
+            }
+    return value
+
+
+def _jsonify_mapped_value(value: Any) -> Any:
+    if value is None:
+        return None
+    normalized = normalize_pyarrow_map_for_json(value)
+    if normalized is value and isinstance(value, Mapping):
+        return {str(k): _jsonify_mapped_value(v) for k, v in value.items()}
+    if normalized is value and isinstance(
+        value, Sequence
+    ) and not isinstance(value, (str, bytes, bytearray)):
+        probe = value[0] if value else None
+        if (
+            isinstance(probe, Sequence)
+            and not isinstance(probe, (str, bytes, bytearray))
+            and len(probe) == 2
+        ):
+            return normalize_pyarrow_map_for_json(list(value))
+        return [_jsonify_mapped_value(item) for item in value]
+    if normalized is not value:
+        return normalized
+    return _jsonify_plain(value)

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -6,10 +6,12 @@ import sys
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
+import pyarrow as pa
 from pyiceberg.expressions import AlwaysTrue, GreaterThan
 from pyiceberg.types import TimestampType
 from singer_sdk import Stream  # JSON Schema typing helpers
 
+from tap_iceberg.map_json import normalize_pyarrow_map_for_json
 from tap_iceberg.utils import generate_schema_from_pyarrow
 
 if TYPE_CHECKING:
@@ -37,6 +39,10 @@ class IcebergTableStream(Stream):
         schema = generate_schema_from_pyarrow(iceberg_table.schema().as_arrow())
         super().__init__(tap, schema, name)
         self._iceberg_table = iceberg_table
+        arrow_schema = iceberg_table.schema().as_arrow()
+        self._map_column_names = frozenset(
+            field.name for field in arrow_schema if pa.types.is_map(field.type)
+        )
 
         sort_fields = self._iceberg_table.sort_order().fields
         if len(sort_fields) == 1:
@@ -77,6 +83,11 @@ class IcebergTableStream(Stream):
         for batch in batch_reader:
             records = batch.to_pylist()
             for record in records:
+                if self._map_column_names:
+                    record = dict(record)
+                    for col in self._map_column_names:
+                        if col in record:
+                            record[col] = normalize_pyarrow_map_for_json(record[col])
                 yield self._format_record(record, formatters)
 
     def _create_formatters(self) -> dict[str, Callable[[Any], Any]]:

--- a/tap_iceberg/tap.py
+++ b/tap_iceberg/tap.py
@@ -140,16 +140,22 @@ class TapIceberg(Tap):
                 self.config["client_iam_role_arn"],
                 role_session_name,
             )
-            os.environ["AWS_ACCESS_KEY_ID"] = client_access_key_id
-            os.environ["AWS_SECRET_ACCESS_KEY"] = client_secret_access_key
-            os.environ["AWS_SESSION_TOKEN"] = client_session_token
-            credentials = Credentials(
-                access_key=client_access_key_id,
-                secret_key=client_secret_access_key,
-                token=client_session_token,
-            )
+            if client_access_key_id:
+                os.environ["AWS_ACCESS_KEY_ID"] = client_access_key_id
+            if client_secret_access_key:
+                os.environ["AWS_SECRET_ACCESS_KEY"] = client_secret_access_key
+            if client_session_token:
+                os.environ["AWS_SESSION_TOKEN"] = client_session_token
+
+            base_credentials = None
+            if client_access_key_id and client_secret_access_key:
+                base_credentials = Credentials(
+                    access_key=client_access_key_id,
+                    secret_key=client_secret_access_key,
+                    token=client_session_token,
+                )
             botocore_session = get_refreshable_botocore_session(
-                source_credentials=credentials,
+                source_credentials=base_credentials,
                 assume_role_arn=self.config["client_iam_role_arn"],
                 role_session_name=role_session_name,
             )

--- a/tap_iceberg/utils.py
+++ b/tap_iceberg/utils.py
@@ -24,17 +24,27 @@ def get_refreshable_botocore_session(
             aws_secret_access_key=source_credentials.secret_key,
             aws_session_token=source_credentials.token,
         )
+        fetcher_source = source_credentials
     else:
         boto3_session = Session()
+        fetcher_source = boto3_session.get_credentials()
+        if fetcher_source is None:
+            msg = (
+                "No AWS credentials found to assume the IAM role. Configure "
+                "client_access_key_id and client_secret_access_key, or set up "
+                "default credentials (e.g. AWS_PROFILE, ~/.aws/credentials, "
+                "aws sso login)."
+            )
+            raise ValueError(msg)
 
     extra_args = {}
     if role_session_name:
         extra_args["RoleSessionName"] = role_session_name
     fetcher = AssumeRoleCredentialFetcher(
         client_creator=boto3_session.client,
-        source_credentials=source_credentials,
+        source_credentials=fetcher_source,
         role_arn=assume_role_arn,
-        extra_args={},
+        extra_args=extra_args,
     )
     refreshable_credentials = DeferredRefreshableCredentials(
         method="assume-role",

--- a/tests/test_map_normalization.py
+++ b/tests/test_map_normalization.py
@@ -1,0 +1,33 @@
+"""Tests for PyArrow map -> JSON object normalization."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from tap_iceberg.map_json import normalize_pyarrow_map_for_json
+
+
+def test_map_as_list_of_pairs_with_decimal_values() -> None:
+    raw: list[list[object]] = [
+        [10, Decimal("0.9075639941274131")],
+        [60, Decimal("0.47395735400544153")],
+        [120, Decimal("0.2382985750117097")],
+        [300, Decimal("0.06791050268829706")],
+    ]
+    out = normalize_pyarrow_map_for_json(raw)
+    assert out == {
+        "10": 0.9075639941274131,
+        "60": 0.47395735400544153,
+        "120": 0.2382985750117097,
+        "300": 0.06791050268829706,
+    }
+
+
+def test_map_as_arrow_struct_rows() -> None:
+    rows = [{"key": 10, "value": 1.5}, {"key": 20, "value": 2.5}]
+    out = normalize_pyarrow_map_for_json(rows)
+    assert out == {"10": 1.5, "20": 2.5}
+
+
+def test_map_empty_sequence() -> None:
+    assert normalize_pyarrow_map_for_json([]) == {}


### PR DESCRIPTION
## Summary
Fixes Singer **record vs catalog** validation failures on **Iceberg `map`** columns (e.g. `target-clickhouse` / `InvalidRecord`) and hardens **Glue assume-role** when optional access keys are omitted.

## Problem
- **Maps:** PyIceberg / Arrow `to_pylist()` often represents **map** fields as **lists of `[key, value]` pairs** (with `Decimal` values), while the tap’s JSON Schema models maps as **JSON objects** (`type: object`, `additionalProperties: number`). Strict loaders validate against the schema and reject the payload.
- **AWS:** With `client_iam_role_arn` set and no keys in config, the tap could assign **`None` to `os.environ`**, and assume-role needed a **non-null** credential source for botocore’s fetcher.

## Solution
- **Maps:** After scan, normalize **top-level Arrow `map`** columns to plain JSON objects (string keys, decimals as floats), matching the discovered schema → see `tap_iceberg/map_json.py` and `tap_iceberg/streams.py`.
- **AWS:** Only set env vars when values are present; resolve **default credentials** when assuming a role; pass **`RoleSessionName`** into `AssumeRoleCredentialFetcher` → `tap_iceberg/tap.py`, `tap_iceberg/utils.py`.
- **Tests:** Unit coverage for map normalization → `tests/test_map_normalization.py`.
