### PR TITLE
Fix assume role issue

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -37,6 +37,16 @@ plugins:
     - description: The region of the AWS Glue Data Catalog.
       label: Region
       name: client_region
+    - description: >-
+        Shaped intermediary role (CUSTOMER_DATA_ACCESS_ROLE_ARN or
+        TAP_ICEBERG_*); first AssumeRole hop from IRSA/pod identity.
+      label: Customer data access role ARN
+      name: customer_data_access_role_arn
+    - description: >-
+        Optional customer lake read role ARN; chained after customer data access
+        when using IRSA-first resolution.
+      label: Client IAM role ARN (chained assume)
+      name: client_iam_role_arn
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -38,13 +38,15 @@ plugins:
       label: Region
       name: client_region
     - description: >-
-        Shaped intermediary role (CUSTOMER_DATA_ACCESS_ROLE_ARN or
-        TAP_ICEBERG_*); first AssumeRole hop from IRSA/pod identity.
+        IRSA → intermediary role ARN (CUSTOMER_DATA_ACCESS_ROLE_ARN,
+        TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN, or Meltano setting); required hop
+        when the lake/Glue reader role trusts this principal, not pod identity alone.
       label: Customer data access role ARN
       name: customer_data_access_role_arn
     - description: >-
-        Optional customer lake read role ARN; chained after customer data access
-        when using IRSA-first resolution.
+        Glue/lake reader role ARN (often customer account); second AssumeRole hop
+        after customer_data_access_role_arn. Use without customer_* only when the
+        reader role trust allows ambient IRSA callers.
       label: Client IAM role ARN (chained assume)
       name: client_iam_role_arn
   loaders:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2986,4 +2986,4 @@ s3 = ["fs-s3fs"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.12,!=3.9.7"
-content-hash = "6301ebd476cdaa18c15852c800e96b5789296c40f50826726e90b6c078d7c7ee"
+content-hash = "d7311da9a141ae8d19ea32357d1ebc84ec4e4cf6ecb68bf946970221b49931e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ python = ">=3.8,<3.12,!=3.9.7"
 importlib-resources = { version = "==6.4.*", python = "<3.9" }
 singer-sdk = { version = "~=0.38.0", extras = ["faker",] }
 setuptools = ">=75.3.0,<81"
+boto3 = { version = "~1.35.0" }
 fs-s3fs = { version = "~=1.1.1", optional = true }
 pyiceberg = { git = "https://github.com/shaped-ai/iceberg-python", branch = "main", extras = ["s3fs", "glue", "hive", "sql-sqlite"] }
 pyarrow = { version = "~17.0.0" }

--- a/tap_iceberg/aws_session.py
+++ b/tap_iceberg/aws_session.py
@@ -18,13 +18,7 @@ from botocore.credentials import Credentials
 from botocore.credentials import DeferredRefreshableCredentials
 from botocore.session import Session as BotoSession
 
-# PyIceberg ``PyArrowFileIO`` reads these for S3 only; ``GlueCatalog`` does not use them
-# for the Glue client (it uses ``botocore_session``), so we avoid overriding refreshable Glue
-# credentials while fixing S3 HeadObject identity. See apache/iceberg-python ``pyarrow.py``.
-_PYICEBERG_S3_ACCESS_KEY_ID = "s3.access-key-id"
-_PYICEBERG_S3_SECRET_ACCESS_KEY = "s3.secret-access-key"
-_PYICEBERG_S3_SESSION_TOKEN = "s3.session-token"
-_PYICEBERG_S3_REGION = "s3.region"
+from tap_iceberg.refreshing_pyarrow_io import attach_refreshing_pyarrow_io
 
 STS_DURATION_SECONDS_DEFAULT = 3600
 
@@ -104,47 +98,41 @@ def _defer_assume(
     )
 
 
-def _inject_pyiceberg_s3_credentials_from_botocore_session(
+def _wire_refreshing_pyarrow_io(
     boto_session: BotoSession,
     catalog_properties: MutableMapping[str, Any],
     *,
     client_region: Optional[str],
     logger: logging.Logger,
 ) -> None:
-    """Mirror assumed credentials into PyIceberg S3 props.
+    """Wire PyIceberg to our refreshing PyArrow FileIO.
 
-    ``GlueCatalog`` uses ``botocore_session`` for Glue APIs, but metadata reads use
-    ``PyArrowFileIO``, which ignores ``botocore_session``. Setting ``client.role-arn``
-    makes PyArrow assume that role using the **pod default chain**, bypassing chained STS
-    (ACCESS_DENIED on customer buckets). Snapshot frozen credentials onto ``s3.*`` keys so
-    S3 matches Glue without overriding Glue ``boto3.Session`` credential kwargs.
+    PyArrow's :class:`pyarrow.fs.S3FileSystem` is built once from string properties
+    and the underlying C++ AWS SDK does not refresh those credentials. Snapshotting
+    ``s3.access-key-id`` / ``s3.secret-access-key`` / ``s3.session-token`` works for
+    the first ``DurationSeconds`` window only, then long-running syncs fail on
+    HeadObject with an expired session token.
 
-    Botocore still refreshes credentials for Glue; **S3 reads reuse this snapshot** until
-    the catalog object is recreated (typical tap runs reload once per CLI invocation).
+    Instead we register the chained ``botocore_session`` and let
+    :class:`tap_iceberg.refreshing_pyarrow_io.RefreshingPyArrowFileIO` rebuild the
+    ``S3FileSystem`` whenever its current STS credentials approach expiry.
     """
 
-    credentials = boto_session.get_credentials()
-    if credentials is None:
+    if boto_session.get_credentials() is None:
         logger.warning(
-            "Cannot inject PyIceberg S3 credentials: botocore session has no credentials.",
+            "Cannot wire refreshing PyArrow FileIO: boto session has no credentials.",
         )
         return
 
-    frozen = credentials.get_frozen_credentials()
-    catalog_properties[_PYICEBERG_S3_ACCESS_KEY_ID] = frozen.access_key
-    catalog_properties[_PYICEBERG_S3_SECRET_ACCESS_KEY] = frozen.secret_key
-    tok = frozen.token
-    if tok:
-        catalog_properties[_PYICEBERG_S3_SESSION_TOKEN] = tok
-    else:
-        catalog_properties.pop(_PYICEBERG_S3_SESSION_TOKEN, None)
-    if client_region:
-        catalog_properties.setdefault(_PYICEBERG_S3_REGION, client_region)
-
+    key = attach_refreshing_pyarrow_io(
+        catalog_properties,  # type: ignore[arg-type]
+        boto_session,
+        client_region=client_region,
+    )
     logger.debug(
-        "Injected PyIceberg S3 credential snapshot for HeadObject reads "
-        "(access_key_suffix=%s)",
-        frozen.access_key[-4:] if frozen.access_key else "",
+        "Wired RefreshingPyArrowFileIO (session_key_suffix=%s, region=%s)",
+        key[-4:],
+        client_region or "<ambient>",
     )
 
 
@@ -160,10 +148,11 @@ def attach_catalog_aws_credentials(
     Exactly one choke point for STS / boto sessions consumed by PyIceberg.
     Logs a credential mode suitable for observability (**no secrets**).
 
-    Refreshable AssumeRole chains attach ``botocore_session`` for Glue APIs and mirror the
-    current frozen credentials into PyIceberg ``s3.*`` properties so PyArrow S3 reads use the
-    same identity (PyArrow ignores ``botocore_session`` and ``client.role-arn`` would otherwise
-    re-assume using only the pod chain).
+    Refreshable AssumeRole chains attach ``botocore_session`` for Glue APIs and wire
+    :class:`tap_iceberg.refreshing_pyarrow_io.RefreshingPyArrowFileIO` as ``py-io-impl``
+    so PyArrow S3 reads also follow chained STS expiry — without this, the C++ AWS SDK
+    used by ``pyarrow.fs.S3FileSystem`` keeps the first frozen session token and long
+    syncs eventually hit ``HeadObject`` 400/UNKNOWN once that token expires.
 
     Resolution order::
 
@@ -235,7 +224,7 @@ def attach_catalog_aws_credentials(
                 method="sts-assume-role-legacy-env",
             )
             catalog_properties["botocore_session"] = boto_session
-            _inject_pyiceberg_s3_credentials_from_botocore_session(
+            _wire_refreshing_pyarrow_io(
                 boto_session,
                 catalog_properties,
                 client_region=client_region,
@@ -289,7 +278,7 @@ def attach_catalog_aws_credentials(
         boto_session = BotoSession()
         boto_session._credentials = final  # noqa: SLF001
         catalog_properties["botocore_session"] = boto_session
-        _inject_pyiceberg_s3_credentials_from_botocore_session(
+        _wire_refreshing_pyarrow_io(
             boto_session,
             catalog_properties,
             client_region=client_region,
@@ -336,7 +325,7 @@ def attach_catalog_aws_credentials(
             method="sts-default-chain-assume",
         )
         catalog_properties["botocore_session"] = boto_session
-        _inject_pyiceberg_s3_credentials_from_botocore_session(
+        _wire_refreshing_pyarrow_io(
             boto_session,
             catalog_properties,
             client_region=client_region,

--- a/tap_iceberg/aws_session.py
+++ b/tap_iceberg/aws_session.py
@@ -18,6 +18,14 @@ from botocore.credentials import Credentials
 from botocore.credentials import DeferredRefreshableCredentials
 from botocore.session import Session as BotoSession
 
+# PyIceberg ``PyArrowFileIO`` reads these for S3 only; ``GlueCatalog`` does not use them
+# for the Glue client (it uses ``botocore_session``), so we avoid overriding refreshable Glue
+# credentials while fixing S3 HeadObject identity. See apache/iceberg-python ``pyarrow.py``.
+_PYICEBERG_S3_ACCESS_KEY_ID = "s3.access-key-id"
+_PYICEBERG_S3_SECRET_ACCESS_KEY = "s3.secret-access-key"
+_PYICEBERG_S3_SESSION_TOKEN = "s3.session-token"
+_PYICEBERG_S3_REGION = "s3.region"
+
 STS_DURATION_SECONDS_DEFAULT = 3600
 
 _STS_RETRY_CONFIG = Config(
@@ -96,6 +104,50 @@ def _defer_assume(
     )
 
 
+def _inject_pyiceberg_s3_credentials_from_botocore_session(
+    boto_session: BotoSession,
+    catalog_properties: MutableMapping[str, Any],
+    *,
+    client_region: Optional[str],
+    logger: logging.Logger,
+) -> None:
+    """Mirror assumed credentials into PyIceberg S3 props.
+
+    ``GlueCatalog`` uses ``botocore_session`` for Glue APIs, but metadata reads use
+    ``PyArrowFileIO``, which ignores ``botocore_session``. Setting ``client.role-arn``
+    makes PyArrow assume that role using the **pod default chain**, bypassing chained STS
+    (ACCESS_DENIED on customer buckets). Snapshot frozen credentials onto ``s3.*`` keys so
+    S3 matches Glue without overriding Glue ``boto3.Session`` credential kwargs.
+
+    Botocore still refreshes credentials for Glue; **S3 reads reuse this snapshot** until
+    the catalog object is recreated (typical tap runs reload once per CLI invocation).
+    """
+
+    credentials = boto_session.get_credentials()
+    if credentials is None:
+        logger.warning(
+            "Cannot inject PyIceberg S3 credentials: botocore session has no credentials.",
+        )
+        return
+
+    frozen = credentials.get_frozen_credentials()
+    catalog_properties[_PYICEBERG_S3_ACCESS_KEY_ID] = frozen.access_key
+    catalog_properties[_PYICEBERG_S3_SECRET_ACCESS_KEY] = frozen.secret_key
+    tok = frozen.token
+    if tok:
+        catalog_properties[_PYICEBERG_S3_SESSION_TOKEN] = tok
+    else:
+        catalog_properties.pop(_PYICEBERG_S3_SESSION_TOKEN, None)
+    if client_region:
+        catalog_properties.setdefault(_PYICEBERG_S3_REGION, client_region)
+
+    logger.debug(
+        "Injected PyIceberg S3 credential snapshot for HeadObject reads "
+        "(access_key_suffix=%s)",
+        frozen.access_key[-4:] if frozen.access_key else "",
+    )
+
+
 def attach_catalog_aws_credentials(
     catalog_properties: MutableMapping[str, Any],
     *,
@@ -107,6 +159,11 @@ def attach_catalog_aws_credentials(
 
     Exactly one choke point for STS / boto sessions consumed by PyIceberg.
     Logs a credential mode suitable for observability (**no secrets**).
+
+    Refreshable AssumeRole chains attach ``botocore_session`` for Glue APIs and mirror the
+    current frozen credentials into PyIceberg ``s3.*`` properties so PyArrow S3 reads use the
+    same identity (PyArrow ignores ``botocore_session`` and ``client.role-arn`` would otherwise
+    re-assume using only the pod chain).
 
     Resolution order::
 
@@ -178,8 +235,12 @@ def attach_catalog_aws_credentials(
                 method="sts-assume-role-legacy-env",
             )
             catalog_properties["botocore_session"] = boto_session
-            catalog_properties["client.role-arn"] = client_iam_arn
-            catalog_properties["client.session-name"] = "TapIcebergLegacyAssume"
+            _inject_pyiceberg_s3_credentials_from_botocore_session(
+                boto_session,
+                catalog_properties,
+                client_region=client_region,
+                logger=logger,
+            )
             return CredentialModeLegacyEnv
 
         catalog_properties["client.access-key-id"] = access_key
@@ -213,27 +274,27 @@ def attach_catalog_aws_credentials(
         )
 
         if client_iam_arn:
-            sess_name_client = "TapIcebergClientRole"
             fetcher_client = AssumeRoleCredentialFetcher(
                 client_creator=client_creator,
                 source_credentials=deferred_customer,
                 role_arn=client_iam_arn,
-                extra_args=_assume_extra(sess_name_client),
+                extra_args=_assume_extra("TapIcebergClientRole"),
             )
             final = _defer_assume(fetcher_client, method="sts-client-role")
             effective_arn = client_iam_arn
-            session_hint = sess_name_client
         else:
-            sess_name_customer = "TapIcebergCustomerDataAccess"
             final = deferred_customer
             effective_arn = customer_arn
-            session_hint = sess_name_customer
 
         boto_session = BotoSession()
         boto_session._credentials = final  # noqa: SLF001
         catalog_properties["botocore_session"] = boto_session
-        catalog_properties["client.role-arn"] = effective_arn
-        catalog_properties["client.session-name"] = session_hint
+        _inject_pyiceberg_s3_credentials_from_botocore_session(
+            boto_session,
+            catalog_properties,
+            client_region=client_region,
+            logger=logger,
+        )
 
         logger.info(
             "AWS credential mode: %s — chained refreshable STS (effective role ...%s)",
@@ -275,8 +336,12 @@ def attach_catalog_aws_credentials(
             method="sts-default-chain-assume",
         )
         catalog_properties["botocore_session"] = boto_session
-        catalog_properties["client.role-arn"] = client_iam_arn
-        catalog_properties["client.session-name"] = "TapIcebergCallerAssume"
+        _inject_pyiceberg_s3_credentials_from_botocore_session(
+            boto_session,
+            catalog_properties,
+            client_region=client_region,
+            logger=logger,
+        )
 
         logger.info(
             "AWS credential mode: %s — AssumeRole (...%s) from ambient caller",

--- a/tap_iceberg/aws_session.py
+++ b/tap_iceberg/aws_session.py
@@ -1,0 +1,246 @@
+"""AWS credentials choke point for the Glue-backed Iceberg catalog.
+
+Supports:
+    * Legacy static ``client_access_key_id`` / ``client_secret_access_key`` (+ token)
+    * Default-chain (IRSA) + refreshable ``sts:AssumeRole`` with optional chaining
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Mapping, MutableMapping, Optional
+
+from boto3 import Session as Boto3Session
+from botocore.config import Config
+from botocore.credentials import AssumeRoleCredentialFetcher
+from botocore.credentials import Credentials
+from botocore.credentials import DeferredRefreshableCredentials
+from botocore.session import Session as BotoSession
+
+STS_DURATION_SECONDS_DEFAULT = 3600
+
+_STS_RETRY_CONFIG = Config(
+    retries={"max_attempts": 10, "mode": "adaptive"},
+)
+
+CredentialModeLegacyEnv = "legacy_env"
+CredentialModeRefreshableIrsaCustomerDataAccessChain = (
+    "refreshable_irsa_customer_data_access_chain"
+)
+CredentialModeRefreshableIrsaClientRoleOnly = "refreshable_irsa_client_role_only"
+CredentialModeDefaultChainDirectCatalog = "default_chain_direct_catalog"
+
+
+def _customer_data_arn(
+    config: Mapping[str, Any],
+    getenv: Callable[[str], Optional[str]],
+) -> Optional[str]:
+    v = (
+        (config.get("customer_data_access_role_arn") or "").strip()
+        or (getenv("CUSTOMER_DATA_ACCESS_ROLE_ARN") or "").strip()
+    )
+    return v or None
+
+
+def _assume_extra(role_session_name: str) -> dict[str, Any]:
+    return {
+        "RoleSessionName": role_session_name,
+        "DurationSeconds": STS_DURATION_SECONDS_DEFAULT,
+    }
+
+
+def _sts_client_creator(region_name: Optional[str]) -> Callable[..., Any]:
+    """Build an AssumeRole-compatible ``client_creator`` (see botocore)."""
+
+    def _client_creator(service_name: str, **kwargs: Any) -> Any:
+        merged = dict(kwargs)
+        merged.setdefault("config", _STS_RETRY_CONFIG)
+        if region_name:
+            merged.setdefault("region_name", region_name)
+        return Boto3Session().client(service_name, **merged)
+
+    return _client_creator
+
+
+def _defer_assume(
+    fetcher: AssumeRoleCredentialFetcher,
+    *,
+    method: str,
+) -> DeferredRefreshableCredentials:
+    return DeferredRefreshableCredentials(
+        refresh_using=fetcher.fetch_credentials,
+        method=method,
+    )
+
+
+def attach_catalog_aws_credentials(
+    catalog_properties: MutableMapping[str, Any],
+    *,
+    config: Mapping[str, Any],
+    logger: logging.Logger,
+    getenv: Callable[[str], Optional[str]] = os.getenv,
+) -> str:
+    """Mutate Iceberg Glue ``catalog_properties`` for AWS auth.
+
+    Exactly one choke point for STS / boto sessions consumed by PyIceberg.
+    Logs a credential mode suitable for observability (**no secrets**).
+
+    Resolution order::
+
+        * Legacy AKIA + secret (+ token) wins:
+            assume ``client_iam_role_arn`` with static base creds, or static keys only.
+        * Else ``CUSTOMER_DATA_ACCESS_ROLE_ARN`` / ``customer_data_access_role_arn``
+          with default-chain base credentials (IRSA), optional second hop via
+          ``client_iam_role_arn``.
+        * Else ``client_iam_role_arn`` alone with default chain.
+        * Else rely on boto3 ambient defaults (**may not** reach customer buckets).
+    """
+    access_key = config.get("client_access_key_id")
+    secret_key = config.get("client_secret_access_key")
+    session_token = config.get("client_session_token")
+    client_region = config.get("client_region")
+    customer_arn = _customer_data_arn(config, getenv)
+    client_iam_arn = (
+        (config.get("client_iam_role_arn") or "").strip() or None
+    )
+
+    if client_region:
+        catalog_properties["client.region"] = client_region
+        os.environ.setdefault("AWS_DEFAULT_REGION", client_region)
+
+    client_creator = _sts_client_creator(client_region)
+
+    if access_key and secret_key:
+        if client_iam_arn:
+            logger.info(
+                "AWS credential mode: %s — refreshable STS from static caller "
+                "assume role (...%s)",
+                CredentialModeLegacyEnv,
+                client_iam_arn[-12:],
+            )
+            os.environ["AWS_ACCESS_KEY_ID"] = access_key
+            os.environ["AWS_SECRET_ACCESS_KEY"] = secret_key
+            if session_token:
+                os.environ["AWS_SESSION_TOKEN"] = session_token
+            else:
+                os.environ.pop("AWS_SESSION_TOKEN", None)
+            fetcher = AssumeRoleCredentialFetcher(
+                client_creator=client_creator,
+                source_credentials=Credentials(
+                    access_key=access_key,
+                    secret_key=secret_key,
+                    token=session_token,
+                ),
+                role_arn=client_iam_arn,
+                extra_args=_assume_extra("TapIcebergLegacyAssume"),
+            )
+            boto_session = BotoSession()
+            boto_session._credentials = _defer_assume(  # noqa: SLF001
+                fetcher,
+                method="sts-assume-role-legacy-env",
+            )
+            catalog_properties["botocore_session"] = boto_session
+            catalog_properties["client.role-arn"] = client_iam_arn
+            catalog_properties["client.session-name"] = "TapIcebergLegacyAssume"
+            return CredentialModeLegacyEnv
+
+        catalog_properties["client.access-key-id"] = access_key
+        catalog_properties["client.secret-access-key"] = secret_key
+        if session_token:
+            catalog_properties["client.session-token"] = session_token
+        logger.info(
+            "AWS credential mode: %s — static Glue client properties",
+            CredentialModeLegacyEnv,
+        )
+        return CredentialModeLegacyEnv
+
+    if customer_arn:
+        base_sess = Boto3Session(region_name=client_region) if client_region else Boto3Session()
+        caller = base_sess.get_credentials()
+        if caller is None:
+            raise ValueError(
+                "CUSTOMER_DATA_ACCESS_ROLE_ARN is set but the default credential "
+                "chain yielded no caller credentials (verify IRSA / pod identity)."
+            )
+
+        fetcher_customer = AssumeRoleCredentialFetcher(
+            client_creator=client_creator,
+            source_credentials=caller,
+            role_arn=customer_arn,
+            extra_args=_assume_extra("TapIcebergCustomerDataAccess"),
+        )
+        deferred_customer = _defer_assume(
+            fetcher_customer,
+            method="sts-customer-data-access",
+        )
+
+        if client_iam_arn:
+            sess_name_client = "TapIcebergClientRole"
+            fetcher_client = AssumeRoleCredentialFetcher(
+                client_creator=client_creator,
+                source_credentials=deferred_customer,
+                role_arn=client_iam_arn,
+                extra_args=_assume_extra(sess_name_client),
+            )
+            final = _defer_assume(fetcher_client, method="sts-client-role")
+            effective_arn = client_iam_arn
+            session_hint = sess_name_client
+        else:
+            sess_name_customer = "TapIcebergCustomerDataAccess"
+            final = deferred_customer
+            effective_arn = customer_arn
+            session_hint = sess_name_customer
+
+        boto_session = BotoSession()
+        boto_session._credentials = final  # noqa: SLF001
+        catalog_properties["botocore_session"] = boto_session
+        catalog_properties["client.role-arn"] = effective_arn
+        catalog_properties["client.session-name"] = session_hint
+
+        logger.info(
+            "AWS credential mode: %s — chained refreshable STS (effective role ...%s)",
+            CredentialModeRefreshableIrsaCustomerDataAccessChain,
+            effective_arn[-12:],
+        )
+        return CredentialModeRefreshableIrsaCustomerDataAccessChain
+
+    if client_iam_arn:
+        base_sess = (
+            Boto3Session(region_name=client_region) if client_region else Boto3Session()
+        )
+        fetcher_src = base_sess.get_credentials()
+        if fetcher_src is None:
+            raise ValueError(
+                "client_iam_role_arn is set without static keys "
+                "and the default credential chain has no caller credentials.",
+            )
+
+        fetcher = AssumeRoleCredentialFetcher(
+            client_creator=client_creator,
+            source_credentials=fetcher_src,
+            role_arn=client_iam_arn,
+            extra_args=_assume_extra("TapIcebergCallerAssume"),
+        )
+        boto_session = BotoSession()
+        boto_session._credentials = _defer_assume(  # noqa: SLF001
+            fetcher,
+            method="sts-default-chain-assume",
+        )
+        catalog_properties["botocore_session"] = boto_session
+        catalog_properties["client.role-arn"] = client_iam_arn
+        catalog_properties["client.session-name"] = "TapIcebergCallerAssume"
+
+        logger.info(
+            "AWS credential mode: %s — AssumeRole (...%s) from ambient caller",
+            CredentialModeRefreshableIrsaClientRoleOnly,
+            client_iam_arn[-12:],
+        )
+        return CredentialModeRefreshableIrsaClientRoleOnly
+
+    logger.warning(
+        "AWS credential mode: %s — neither static trio, intermediary role ARN, "
+        "nor client_iam_role_arn configured; Glue may rely on boto3 defaults only.",
+        CredentialModeDefaultChainDirectCatalog,
+    )
+    return CredentialModeDefaultChainDirectCatalog

--- a/tap_iceberg/aws_session.py
+++ b/tap_iceberg/aws_session.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Mapping, MutableMapping, Optional
+from typing import Any, Callable, Mapping, MutableMapping, NamedTuple, Optional
 
 from boto3 import Session as Boto3Session
 from botocore.config import Config
@@ -32,15 +32,37 @@ CredentialModeRefreshableIrsaClientRoleOnly = "refreshable_irsa_client_role_only
 CredentialModeDefaultChainDirectCatalog = "default_chain_direct_catalog"
 
 
-def _customer_data_arn(
+class CustomerDataAccessArnResolution(NamedTuple):
+    """Resolved first-hop AssumeRole ARN and where it came from."""
+
+    arn: Optional[str]
+    """Effective ARN after config-then-env resolution."""
+    source: str
+    """``config``, ``env:<VAR_NAME>``, or ``none``."""
+
+
+CUSTOMER_DATA_ACCESS_ENV_KEYS = (
+    "TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN",
+    "CUSTOMER_DATA_ACCESS_ROLE_ARN",
+)
+
+
+def _customer_data_access_arn_resolve(
     config: Mapping[str, Any],
     getenv: Callable[[str], Optional[str]],
-) -> Optional[str]:
-    v = (
-        (config.get("customer_data_access_role_arn") or "").strip()
-        or (getenv("CUSTOMER_DATA_ACCESS_ROLE_ARN") or "").strip()
-    )
-    return v or None
+) -> CustomerDataAccessArnResolution:
+    """Resolve first-hop role (IRSA → CustomerS3DataAccessRole) ARN."""
+
+    cfg = (config.get("customer_data_access_role_arn") or "").strip()
+    if cfg:
+        return CustomerDataAccessArnResolution(cfg, "config")
+
+    for key in CUSTOMER_DATA_ACCESS_ENV_KEYS:
+        cand = (getenv(key) or "").strip()
+        if cand:
+            return CustomerDataAccessArnResolution(cand, f"env:{key}")
+
+    return CustomerDataAccessArnResolution(None, "none")
 
 
 def _assume_extra(role_session_name: str) -> dict[str, Any]:
@@ -90,19 +112,34 @@ def attach_catalog_aws_credentials(
 
         * Legacy AKIA + secret (+ token) wins:
             assume ``client_iam_role_arn`` with static base creds, or static keys only.
-        * Else ``CUSTOMER_DATA_ACCESS_ROLE_ARN`` / ``customer_data_access_role_arn``
-          with default-chain base credentials (IRSA), optional second hop via
-          ``client_iam_role_arn``.
-        * Else ``client_iam_role_arn`` alone with default chain.
+        * Else ``customer_data_access_role_arn`` env:
+            ``TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN`` or ``CUSTOMER_DATA_ACCESS_ROLE_ARN``,
+            resolved with default-chain (IRSA), optional second AssumeRole hop via
+            ``client_iam_role_arn`` (Glue / lake reader in the customer's account).
+        * Else ``client_iam_role_arn`` alone with default chain (caller must satisfy the
+          reader role trust policy).
         * Else rely on boto3 ambient defaults (**may not** reach customer buckets).
     """
     access_key = config.get("client_access_key_id")
     secret_key = config.get("client_secret_access_key")
     session_token = config.get("client_session_token")
     client_region = config.get("client_region")
-    customer_arn = _customer_data_arn(config, getenv)
+    customer_arn_res = _customer_data_access_arn_resolve(config, getenv)
+    customer_arn = customer_arn_res.arn
     client_iam_arn = (
         (config.get("client_iam_role_arn") or "").strip() or None
+    )
+
+    env_audit = "; ".join(
+        f"{k}={'set' if bool((getenv(k) or '').strip()) else 'unset'}"
+        for k in CUSTOMER_DATA_ACCESS_ENV_KEYS
+    )
+    logger.info(
+        "Customer data access role ARN: resolution_source=%s effective_arn_suffix=%s. "
+        "Env vars: %s",
+        customer_arn_res.source,
+        customer_arn[-12:] if customer_arn else "none",
+        env_audit,
     )
 
     if client_region:
@@ -160,8 +197,8 @@ def attach_catalog_aws_credentials(
         caller = base_sess.get_credentials()
         if caller is None:
             raise ValueError(
-                "CUSTOMER_DATA_ACCESS_ROLE_ARN is set but the default credential "
-                "chain yielded no caller credentials (verify IRSA / pod identity)."
+                "First-hop intermediary role ARN is set but the default credential chain "
+                "yielded no caller credentials (verify IRSA / pod identity)."
             )
 
         fetcher_customer = AssumeRoleCredentialFetcher(
@@ -215,6 +252,16 @@ def attach_catalog_aws_credentials(
                 "client_iam_role_arn is set without static keys "
                 "and the default credential chain has no caller credentials.",
             )
+
+        logger.warning(
+            "One-hop STS: ambient caller AssumeRole directly into configured "
+            "client_iam_role_arn (...%s). If AssumeRole yields AccessDenied, the reader "
+            "role trust likely requires chaining: set "
+            "customer_data_access_role_arn (or TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN / "
+            "CUSTOMER_DATA_ACCESS_ROLE_ARN) for the intermediary role your pod identity "
+            "may assume before this reader role.",
+            client_iam_arn[-12:],
+        )
 
         fetcher = AssumeRoleCredentialFetcher(
             client_creator=client_creator,

--- a/tap_iceberg/refreshing_pyarrow_io.py
+++ b/tap_iceberg/refreshing_pyarrow_io.py
@@ -1,0 +1,224 @@
+"""Refreshing PyArrow FileIO so long Iceberg syncs survive STS expiry.
+
+PyIceberg's default :class:`pyiceberg.io.pyarrow.PyArrowFileIO` creates a
+:class:`pyarrow.fs.S3FileSystem` once from ``s3.access-key-id`` /
+``s3.secret-access-key`` / ``s3.session-token`` strings. The underlying C++
+AWS SDK does not refresh those, so any sync that outlives the assumed-role
+``DurationSeconds`` (~1h with our STS settings, jittered by botocore) fails
+with HTTP 400/UNKNOWN HeadObject errors even when ``botocore_session`` keeps
+refreshing fine for Glue calls.
+
+``RefreshingPyArrowFileIO`` keeps the same ``botocore.session.Session`` we
+already use for Glue and rebuilds the S3 client whenever current credentials
+fall inside a small refresh window before expiry. PyIceberg can only pass
+string properties through ``load_catalog``, so the session is exchanged via
+``register_botocore_session`` + a token written to ``catalog_properties``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from pyarrow.fs import FileSystem, S3FileSystem
+from pyiceberg.io.pyarrow import PyArrowFileIO
+from pyiceberg.typedef import EMPTY_DICT, Properties
+
+logger = logging.getLogger(__name__)
+
+SESSION_KEY_PROPERTY = "tap_iceberg.botocore_session_key"
+"""Catalog property name that holds the registry key for the boto session."""
+
+PY_IO_IMPL_PATH = "tap_iceberg.refreshing_pyarrow_io.RefreshingPyArrowFileIO"
+"""Fully-qualified path PyIceberg loads as :class:`PyArrowFileIO` replacement."""
+
+_REFRESH_WINDOW_SECONDS = 300
+"""Rebuild ``S3FileSystem`` if its credentials expire within this many seconds."""
+
+_STATIC_CACHE_TTL_SECONDS = 60 * 60 * 24
+"""Cache static credentials (no expiry attached) for a long, finite TTL."""
+
+_REGISTRY_LOCK = threading.Lock()
+_BOTOCORE_SESSION_REGISTRY: Dict[str, Any] = {}
+
+
+def register_botocore_session(session: Any) -> str:
+    """Register a ``botocore`` session and return a registry token.
+
+    The token is written to ``catalog_properties`` so PyIceberg (which only
+    accepts string properties) can hand it back to the FileIO at construction
+    time. Sessions are intentionally **not** removed automatically — taps run
+    in their own short-lived process and a global dict avoids life-cycle
+    coupling with PyIceberg's catalog/FileIO objects.
+    """
+    key = uuid.uuid4().hex
+    with _REGISTRY_LOCK:
+        _BOTOCORE_SESSION_REGISTRY[key] = session
+    return key
+
+
+def _lookup_botocore_session(key: Optional[str]) -> Optional[Any]:
+    if not key:
+        return None
+    with _REGISTRY_LOCK:
+        return _BOTOCORE_SESSION_REGISTRY.get(key)
+
+
+def _expiry_to_epoch(expiry: Any) -> Optional[float]:
+    if expiry is None:
+        return None
+    if isinstance(expiry, datetime):
+        return expiry.timestamp()
+    try:
+        return float(expiry)
+    except (TypeError, ValueError):
+        return None
+
+
+class RefreshingPyArrowFileIO(PyArrowFileIO):
+    """``PyArrowFileIO`` that rebuilds ``S3FileSystem`` from refreshable STS creds.
+
+    Non-S3 schemes (``file://``, ``hdfs://``, ``gs://``) fall through to
+    upstream ``PyArrowFileIO`` behavior. S3 schemes go through
+    :meth:`_build_or_get_s3_fs`, which is invoked on every file open via the
+    overridden ``fs_by_scheme`` (we cannot reuse the parent ``lru_cache``
+    because it would pin a stale ``S3FileSystem`` for the life of the IO).
+    """
+
+    def __init__(self, properties: Properties = EMPTY_DICT) -> None:
+        super().__init__(properties=properties)
+        self._session_key: Optional[str] = properties.get(SESSION_KEY_PROPERTY)
+        self._s3_fs_cache: Dict[Tuple[str, Optional[str]], Tuple[float, S3FileSystem]] = {}
+        self._fs_lock = threading.Lock()
+
+        parent_fs_by_scheme = self.fs_by_scheme
+
+        def refreshing_fs_by_scheme(
+            scheme: str,
+            netloc: Optional[str] = None,
+        ) -> FileSystem:
+            if scheme in {"s3", "s3a", "s3n"} and self._session_key:
+                return self._build_or_get_s3_fs(scheme, netloc)
+            return parent_fs_by_scheme(scheme, netloc)
+
+        self.fs_by_scheme = refreshing_fs_by_scheme  # type: ignore[assignment]
+
+    def _build_or_get_s3_fs(
+        self,
+        scheme: str,
+        netloc: Optional[str],
+    ) -> S3FileSystem:
+        cache_key = (scheme, netloc)
+        now = time.time()
+
+        with self._fs_lock:
+            session = _lookup_botocore_session(self._session_key)
+            if session is None:
+                logger.warning(
+                    "RefreshingPyArrowFileIO: no boto session registered for key=%s; "
+                    "falling back to upstream PyArrowFileIO behavior for %s://",
+                    self._session_key,
+                    scheme,
+                )
+                return super()._initialize_fs(scheme, netloc)
+
+            credentials = session.get_credentials()
+            if credentials is None:
+                logger.warning(
+                    "RefreshingPyArrowFileIO: boto session yielded no credentials; "
+                    "falling back to upstream PyArrowFileIO behavior for %s://",
+                    scheme,
+                )
+                return super()._initialize_fs(scheme, netloc)
+
+            # ``get_frozen_credentials`` lets botocore refresh under the hood if the
+            # credentials are within its own advisory window; we then read the
+            # (possibly updated) ``_expiry_time`` to decide whether to reuse a cached
+            # ``S3FileSystem`` or build a fresh one with the new frozen tuple.
+            frozen = credentials.get_frozen_credentials()
+            current_expiry = _expiry_to_epoch(getattr(credentials, "_expiry_time", None))
+            if current_expiry is None:
+                current_expiry = now + _STATIC_CACHE_TTL_SECONDS
+
+            cached = self._s3_fs_cache.get(cache_key)
+            if (
+                cached is not None
+                and cached[0] == current_expiry
+                and current_expiry > now + _REFRESH_WINDOW_SECONDS
+            ):
+                return cached[1]
+
+            s3_fs = self._construct_s3_fs(
+                access_key=frozen.access_key,
+                secret_key=frozen.secret_key,
+                session_token=frozen.token,
+            )
+
+            self._s3_fs_cache[cache_key] = (current_expiry, s3_fs)
+            logger.debug(
+                "RefreshingPyArrowFileIO: built fresh S3FileSystem "
+                "(scheme=%s netloc=%s key_suffix=%s expires_in_s=%d)",
+                scheme,
+                netloc,
+                frozen.access_key[-4:] if frozen.access_key else "",
+                max(0, int(current_expiry - now)),
+            )
+            return s3_fs
+
+    def _construct_s3_fs(
+        self,
+        *,
+        access_key: Optional[str],
+        secret_key: Optional[str],
+        session_token: Optional[str],
+    ) -> S3FileSystem:
+        kwargs: Dict[str, Any] = {
+            "access_key": access_key,
+            "secret_key": secret_key,
+        }
+        if session_token:
+            kwargs["session_token"] = session_token
+
+        region = self.properties.get("s3.region") or self.properties.get("client.region")
+        if region:
+            kwargs["region"] = region
+
+        endpoint = self.properties.get("s3.endpoint")
+        if endpoint:
+            kwargs["endpoint_override"] = endpoint
+
+        proxy = self.properties.get("s3.proxy-uri")
+        if proxy:
+            kwargs["proxy_options"] = proxy
+
+        connect_timeout = self.properties.get("s3.connect-timeout")
+        if connect_timeout:
+            try:
+                kwargs["connect_timeout"] = float(connect_timeout)
+            except (TypeError, ValueError):
+                pass
+
+        return S3FileSystem(**kwargs)
+
+
+def attach_refreshing_pyarrow_io(
+    catalog_properties: Dict[str, Any],
+    boto_session: Any,
+    *,
+    client_region: Optional[str] = None,
+    register: Callable[[Any], str] = register_botocore_session,
+) -> str:
+    """Wire ``catalog_properties`` so PyIceberg uses our refreshing FileIO.
+
+    Returns the registry key, mostly for tests / observability.
+    """
+    key = register(boto_session)
+    catalog_properties["py-io-impl"] = PY_IO_IMPL_PATH
+    catalog_properties[SESSION_KEY_PROPERTY] = key
+    if client_region:
+        catalog_properties.setdefault("s3.region", client_region)
+    return key

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 from pyiceberg.expressions import AlwaysTrue, And, GreaterThan, LessThanOrEqual
 from pyiceberg.types import TimestamptzType
 from singer_sdk import Stream  # JSON Schema typing helpers
+from singer_sdk.helpers._typing import to_json_compatible
 
 from tap_iceberg.map_json import normalize_pyarrow_map_for_json
 from tap_iceberg.utils import generate_schema_from_pyarrow
@@ -138,29 +139,52 @@ class IcebergTableStream(Stream):
         """
         return True
 
+    @property
+    def check_sorted(self) -> bool:
+        """Tail-phase scans may yield records in arbitrary order (PyIceberg
+        manifest order). We compute the bookmark ourselves, so don't let
+        Singer SDK raise InvalidStreamSortException if it ever peeks at
+        records and finds them unsorted.
+        """
+        return False
+
     def _increment_stream_state(self, latest_record, *, context=None) -> None:  # noqa: ARG002
         """No-op: per-record bookmarks are unsafe on randomly-ordered file scans.
-        Bookmark advances only when the whole window completes (_finalize_state).
+        Bookmark advances only when the run completes (see _finalize_state).
         """
         return
 
     def _finalize_state(self, state=None) -> None:
-        """Promote the planned window end to the committed bookmark.
+        """Persist the bookmark once the record generator has completed.
 
-        Singer SDK calls this only when get_records returns cleanly (i.e. the
-        whole window was processed). If SIGTERM kills the generator mid-window,
-        this never runs and the bookmark stays where it was.
+        Backfill phase:
+            ``_planned_bookmark`` was predetermined as ``window_end`` inside
+            :py:meth:`get_records`; we write it as-is.
+        Tail phase:
+            ``_planned_bookmark`` is ``None``; we promote ``_max_observed``
+            (the maximum replication_key value yielded during this run).
+
+        If the generator is interrupted (SIGTERM, crash, eviction), Singer
+        SDK never invokes this method and the persisted bookmark in Meltano
+        Postgres stays at whatever the previous successful run left it.
         """
-        planned_end = getattr(self, "_planned_window_end", None)
-        if planned_end is not None and self.replication_key:
-            stream_state = state if state is not None else self.get_context_state(
-                None,
+        bookmark = getattr(self, "_planned_bookmark", None)
+        if bookmark is None:
+            max_observed = getattr(self, "_max_observed", None)
+            if max_observed is not None:
+                # Reuse Singer's serializer so datetimes / Decimals match the
+                # representation used elsewhere in the state payload.
+                bookmark = to_json_compatible(max_observed)
+
+        if bookmark is not None and self.replication_key:
+            stream_state = (
+                state if state is not None else self.get_context_state(None)
             )
             stream_state["replication_key"] = self.replication_key
-            stream_state["replication_key_value"] = planned_end
+            stream_state["replication_key_value"] = bookmark
             self.logger.info(
                 "Window complete; advancing bookmark to %s",
-                planned_end,
+                bookmark,
             )
         super()._finalize_state(state)
 
@@ -189,16 +213,23 @@ class IcebergTableStream(Stream):
         return isinstance(field.field_type, TimestamptzType)
 
     def get_records(self, context: dict | None = None) -> Iterable[dict]:
-        """Yield records from a single closed time window of the Iceberg table.
+        """Yield records using one of two phases.
 
-        Window = (last_bookmark, last_bookmark + window-size-hours]. PyIceberg's
-        file/manifest order may scatter replication-key values randomly within
-        the unread tail, so we only advance the bookmark when the whole window
-        finishes (handled in _finalize_state). SIGTERM mid-window leaves the
-        bookmark untouched; the next cron retries the same window.
+        Backfill: ``window_start + window_size_hours <= now``.
+            Closed window ``(window_start, window_start + window_size_hours]``.
+            Bookmark advances by exactly ``window_size_hours`` per successful run.
+        Tail: window would overshoot ``now``.
+            Open-ended filter ``updated_at > window_start``.
+            Bookmark advances to the max ``updated_at`` observed during the run.
+
+        In both phases, the bookmark is only persisted by ``_finalize_state``
+        after the generator runs to completion. A crash mid-iteration leaves
+        the bookmark untouched; the next cron retries the same ``window_start``
+        and target dedup absorbs duplicates.
         """
         if self.replication_method != "INCREMENTAL":
-            self._planned_window_end = None
+            self._planned_bookmark = None
+            self._max_observed = None
             yield from self._get_records_full_table(context)
             return
 
@@ -222,31 +253,61 @@ class IcebergTableStream(Stream):
         if column_is_tz_aware:
             if window_start.tzinfo is None:
                 window_start = window_start.replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
         else:
-            # PyIceberg's `TimestampType` rejects literals with a zone offset.
-            # Normalize aware → UTC then strip tzinfo so the column literal matches.
+            # PyIceberg's ``TimestampType`` rejects literals with a zone offset,
+            # so normalize aware -> UTC then strip tzinfo for both window_start
+            # and ``now`` so they remain comparable / serialisable.
             if window_start.tzinfo is not None:
                 window_start = window_start.astimezone(timezone.utc).replace(
                     tzinfo=None,
                 )
-        window_end = window_start + timedelta(hours=int(window_hours))
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
 
-        self.logger.info(
-            "Iceberg windowed scan: %s < %s <= %s (window=%sh, source=%s)",
-            window_start.isoformat(),
-            self.replication_key,
-            window_end.isoformat(),
-            window_hours,
-            "state" if state_bookmark else "bootstrap",
-        )
+        candidate_end = window_start + timedelta(hours=int(window_hours))
 
-        self._planned_window_end = window_end.isoformat()
+        if candidate_end <= now:
+            # ---- Backfill phase: closed (start, end] window ----
+            self._planned_bookmark = candidate_end.isoformat()
+            self._max_observed = None
+            filter_expression = And(
+                GreaterThan(self.replication_key, window_start.isoformat()),
+                LessThanOrEqual(self.replication_key, candidate_end.isoformat()),
+            )
+            self.logger.info(
+                "Iceberg backfill scan [phase=backfill]: %s < %s <= %s "
+                "(window=%sh, source=%s)",
+                window_start.isoformat(),
+                self.replication_key,
+                candidate_end.isoformat(),
+                window_hours,
+                "state" if state_bookmark else "bootstrap",
+            )
+        else:
+            # ---- Tail phase: open-ended scan, running-max bookmark ----
+            self._planned_bookmark = None
+            self._max_observed = None
+            filter_expression = GreaterThan(
+                self.replication_key, window_start.isoformat(),
+            )
+            self.logger.info(
+                "Iceberg tail scan [phase=tail]: %s < %s (running-max bookmark, "
+                "candidate_end=%s would overshoot now=%s)",
+                window_start.isoformat(),
+                self.replication_key,
+                candidate_end.isoformat(),
+                now.isoformat(),
+            )
 
-        filter_expression = And(
-            GreaterThan(self.replication_key, window_start.isoformat()),
-            LessThanOrEqual(self.replication_key, window_end.isoformat()),
-        )
-        yield from self._scan_and_yield_rows(filter_expression)
+        for record in self._scan_and_yield_rows(filter_expression):
+            # Track max only in tail phase; backfill bookmark is predetermined.
+            if self._planned_bookmark is None:
+                rk_value = record.get(self.replication_key)
+                if rk_value is not None and (
+                    self._max_observed is None or rk_value > self._max_observed
+                ):
+                    self._max_observed = rk_value
+            yield record
 
     def _get_records_full_table(self, context: dict | None) -> Iterable[dict]:
         """Non-incremental: scan the whole table."""

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -31,6 +31,8 @@ else:
 logger = logging.getLogger(__name__)
 
 _TAP_METADATA_ENV = "TAP_ICEBERG__METADATA"
+# MagicMock taps auto-vivify arbitrary attrs; avoid treating that as cached parse data.
+_METADATA_CACHE_ABSENT = object()
 
 
 class IcebergTableStream(Stream):
@@ -59,8 +61,9 @@ class IcebergTableStream(Stream):
         """
         tap = self._tap
         cache_attr = "_tap_iceberg_metadata_bundle_from_env_v1"
-        if hasattr(tap, cache_attr):
-            return getattr(tap, cache_attr)
+        cached = getattr(tap, cache_attr, _METADATA_CACHE_ABSENT)
+        if cached is not _METADATA_CACHE_ABSENT:
+            return cached
 
         raw = os.environ.get(_TAP_METADATA_ENV)
         parsed: dict[str, Any] | None = None

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 import sys
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Iterable
@@ -25,6 +28,11 @@ else:
     pass
 
 
+logger = logging.getLogger(__name__)
+
+_TAP_METADATA_ENV = "TAP_ICEBERG__METADATA"
+
+
 class IcebergTableStream(Stream):
     """Stream class for an Iceberg table."""
 
@@ -43,18 +51,76 @@ class IcebergTableStream(Stream):
             field.name for field in arrow_schema if pa.types.is_map(field.type)
         )
 
-    def _get_stream_metadata_value(self, key: str, default=None):
-        """Read a non-spec key from this stream's root metadata entry.
+    def _tap_metadata_bundle_from_env(self) -> dict[str, Any] | None:
+        """Parse TAP_ICEBERG__METADATA JSON (Magnus / Meltano env).
 
-        Magnus injects window-size-hours and start-replication-key-value alongside
-        replication-key in TAP_ICEBERG__METADATA. Singer SDK preserves unknown keys
-        in the underlying dict but doesn't expose them as named attributes.
+        Parsed once per tap instance and cached on ``tap`` so repeated lookups stay
+        cheap.
         """
+        tap = self._tap
+        cache_attr = "_tap_iceberg_metadata_bundle_from_env_v1"
+        if hasattr(tap, cache_attr):
+            return getattr(tap, cache_attr)
+
+        raw = os.environ.get(_TAP_METADATA_ENV)
+        parsed: dict[str, Any] | None = None
+        if raw:
+            try:
+                loaded = json.loads(raw)
+                if isinstance(loaded, dict):
+                    parsed = loaded
+                else:
+                    logger.warning(
+                        "%s must decode to an object at the top level, got %s",
+                        _TAP_METADATA_ENV,
+                        type(loaded).__name__,
+                    )
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "Invalid JSON in %s: %s",
+                    _TAP_METADATA_ENV,
+                    exc,
+                )
+        setattr(tap, cache_attr, parsed)
+        return getattr(tap, cache_attr)
+
+    def _merged_tap_iceberg_metadata_overlay(self) -> dict[str, Any]:
+        """Return merged metadata for this stream id from TAP_ICEBERG__METADATA.
+
+        Meltano typically passes a wildcard block under ``'*'``. Optional per-stream
+        keys matching :attr:`~singer_sdk.streams.core.Stream.name` override the same
+        keys from ``'*'``.
+        """
+        bundle = self._tap_metadata_bundle_from_env()
+        overlay: dict[str, Any] = {}
+        if not isinstance(bundle, dict):
+            return overlay
+        wild = bundle.get("*")
+        if isinstance(wild, dict):
+            overlay.update(wild)
+        specific = bundle.get(self.name)
+        if isinstance(specific, dict):
+            overlay.update(specific)
+        return overlay
+
+    def _get_stream_metadata_value(self, key: str, default=None):
+        """Read a Magnus extension key supplied via TAP_ICEBERG__METADATA.
+
+        Singer's ``StreamMetadata.from_dict()`` only keeps Singer-spec catalogue
+        fields, so entries like ``window-size-hours`` are **dropped** when the
+        catalog is parsed—they must be read from the raw env blob instead.
+
+        Fallback: if catalogue root metadata is stored as a ``dict``, read from
+        there (useful for hand-written catalogs in tests).
+        """
+        overlay = self._merged_tap_iceberg_metadata_overlay()
+        if key in overlay:
+            return overlay[key]
+
         root_md = self.metadata.get((), None)
-        if root_md is None:
-            return default
-        if hasattr(root_md, "get"):
+        if isinstance(root_md, dict):
             return root_md.get(key, default)
+
         return default
 
     @property

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import pyarrow as pa
-from pyiceberg.expressions import AlwaysTrue, GreaterThan
-from pyiceberg.types import TimestampType
+from pyiceberg.expressions import AlwaysTrue, And, GreaterThan, LessThanOrEqual
 from singer_sdk import Stream  # JSON Schema typing helpers
 
 from tap_iceberg.map_json import normalize_pyarrow_map_for_json
@@ -44,40 +43,119 @@ class IcebergTableStream(Stream):
             field.name for field in arrow_schema if pa.types.is_map(field.type)
         )
 
-        sort_fields = self._iceberg_table.sort_order().fields
-        if len(sort_fields) == 1:
-            sort_field_source_id = sort_fields[0].source_id
-            sort_field_name = (
-                self._iceberg_table.schema().find_field(sort_field_source_id).name
-            )
-            self._replication_key = sort_field_name
+    def _get_stream_metadata_value(self, key: str, default=None):
+        """Read a non-spec key from this stream's root metadata entry.
+
+        Magnus injects window-size-hours and start-replication-key-value alongside
+        replication-key in TAP_ICEBERG__METADATA. Singer SDK preserves unknown keys
+        in the underlying dict but doesn't expose them as named attributes.
+        """
+        root_md = self.metadata.get((), None)
+        if root_md is None:
+            return default
+        if hasattr(root_md, "get"):
+            return root_md.get(key, default)
+        return default
 
     @property
     def is_sorted(self) -> bool:
-        return not self._iceberg_table.sort_order().is_unsorted
+        """We bypass Singer SDK's per-record bookmark logic entirely (see
+        _increment_stream_state and _finalize_state). Returning True keeps the
+        SDK from creating progress_markers / signposts that we'd then ignore.
+        """
+        return True
+
+    def _increment_stream_state(self, latest_record, *, context=None) -> None:  # noqa: ARG002
+        """No-op: per-record bookmarks are unsafe on randomly-ordered file scans.
+        Bookmark advances only when the whole window completes (_finalize_state).
+        """
+        return
+
+    def _finalize_state(self, state=None) -> None:
+        """Promote the planned window end to the committed bookmark.
+
+        Singer SDK calls this only when get_records returns cleanly (i.e. the
+        whole window was processed). If SIGTERM kills the generator mid-window,
+        this never runs and the bookmark stays where it was.
+        """
+        planned_end = getattr(self, "_planned_window_end", None)
+        if planned_end is not None and self.replication_key:
+            stream_state = state if state is not None else self.get_context_state(
+                None,
+            )
+            stream_state["replication_key"] = self.replication_key
+            stream_state["replication_key_value"] = planned_end
+            self.logger.info(
+                "Window complete; advancing bookmark to %s",
+                planned_end,
+            )
+        super()._finalize_state(state)
+
+    def get_replication_key_signpost(self, context: dict | None = None):  # noqa: ARG002
+        """Bounded by Iceberg row_filter for incremental windows, not utc_now."""
+        return None
 
     def get_records(self, context: dict | None = None) -> Iterable[dict]:
-        """Return a generator of record-type dictionary objects."""
-        filter_expression = AlwaysTrue()
-        self.logger.info("Starting Iceberg table scan.")
-        start_value = self.get_starting_replication_key_value(context)
-        if start_value:
-            replication_key_field = self._iceberg_table.schema().find_field(
-                self.replication_key
-            )
-            if isinstance(replication_key_field.field_type, (TimestampType)):
-                # Remove offset from replication key if not supported.
-                start_value = start_value.split("+")[0]
+        """Yield records from a single closed time window of the Iceberg table.
 
-            self.logger.info(
-                "Filtering records for replication key %s greater than %s.",
-                self.replication_key,
-                start_value,
+        Window = (last_bookmark, last_bookmark + window-size-hours]. PyIceberg's
+        file/manifest order may scatter replication-key values randomly within
+        the unread tail, so we only advance the bookmark when the whole window
+        finishes (handled in _finalize_state). SIGTERM mid-window leaves the
+        bookmark untouched; the next cron retries the same window.
+        """
+        if self.replication_method != "INCREMENTAL":
+            self._planned_window_end = None
+            yield from self._get_records_full_table(context)
+            return
+
+        window_hours = self._get_stream_metadata_value("window-size-hours")
+        bootstrap_start = self._get_stream_metadata_value(
+            "start-replication-key-value",
+        )
+
+        if window_hours is None or bootstrap_start is None:
+            raise ValueError(
+                f"Stream '{self.name}' requires both 'window-size-hours' and "
+                "'start-replication-key-value' in TAP_ICEBERG__METADATA for "
+                "incremental sync.",
             )
-            filter_expression = GreaterThan(self.replication_key, start_value)
-        batch_reader = self._iceberg_table.scan(
-            row_filter=filter_expression,
-        ).to_arrow_batch_reader()
+
+        state_bookmark = self.get_starting_replication_key_value(context)
+        window_start_str = state_bookmark or bootstrap_start
+
+        window_start = datetime.fromisoformat(window_start_str)
+        if window_start.tzinfo is None:
+            window_start = window_start.replace(tzinfo=timezone.utc)
+        window_end = window_start + timedelta(hours=int(window_hours))
+
+        self.logger.info(
+            "Iceberg windowed scan: %s < %s <= %s (window=%sh, source=%s)",
+            window_start.isoformat(),
+            self.replication_key,
+            window_end.isoformat(),
+            window_hours,
+            "state" if state_bookmark else "bootstrap",
+        )
+
+        self._planned_window_end = window_end.isoformat()
+
+        filter_expression = And(
+            GreaterThan(self.replication_key, window_start.isoformat()),
+            LessThanOrEqual(self.replication_key, window_end.isoformat()),
+        )
+        yield from self._scan_and_yield_rows(filter_expression)
+
+    def _get_records_full_table(self, context: dict | None) -> Iterable[dict]:
+        """Non-incremental: scan the whole table."""
+        _ = context
+        self.logger.info("Starting Iceberg table scan.")
+        yield from self._scan_and_yield_rows(AlwaysTrue())
+
+    def _scan_and_yield_rows(self, row_filter: Any) -> Iterable[dict]:
+        batch_reader = (
+            self._iceberg_table.scan(row_filter=row_filter).to_arrow_batch_reader()
+        )
 
         formatters = self._create_formatters()
         for batch in batch_reader:

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -31,8 +31,6 @@ else:
 logger = logging.getLogger(__name__)
 
 _TAP_METADATA_ENV = "TAP_ICEBERG__METADATA"
-# MagicMock taps auto-vivify arbitrary attrs; avoid treating that as cached parse data.
-_METADATA_CACHE_ABSENT = object()
 
 
 class IcebergTableStream(Stream):
@@ -61,9 +59,11 @@ class IcebergTableStream(Stream):
         """
         tap = self._tap
         cache_attr = "_tap_iceberg_metadata_bundle_from_env_v1"
-        cached = getattr(tap, cache_attr, _METADATA_CACHE_ABSENT)
-        if cached is not _METADATA_CACHE_ABSENT:
-            return cached
+        tap_dict = getattr(tap, "__dict__", None)
+        # unittest.mock.MagicMock never raises AttributeError and ignores getattr
+        # defaults, so probe __dict__ explicitly (real taps also store attrs there).
+        if tap_dict is not None and cache_attr in tap_dict:
+            return tap_dict[cache_attr]
 
         raw = os.environ.get(_TAP_METADATA_ENV)
         parsed: dict[str, Any] | None = None
@@ -84,8 +84,11 @@ class IcebergTableStream(Stream):
                     _TAP_METADATA_ENV,
                     exc,
                 )
-        setattr(tap, cache_attr, parsed)
-        return getattr(tap, cache_attr)
+        if tap_dict is not None:
+            tap_dict[cache_attr] = parsed
+        else:
+            setattr(tap, cache_attr, parsed)
+        return parsed
 
     def _merged_tap_iceberg_metadata_overlay(self) -> dict[str, Any]:
         """Return merged metadata for this stream id from TAP_ICEBERG__METADATA.

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -10,7 +10,13 @@ from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import pyarrow as pa
-from pyiceberg.expressions import AlwaysTrue, And, GreaterThan, LessThanOrEqual
+from pyiceberg.expressions import (
+    AlwaysTrue,
+    And,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual,
+)
 from pyiceberg.types import TimestamptzType
 from singer_sdk import Stream  # JSON Schema typing helpers
 from singer_sdk.helpers._typing import to_json_compatible
@@ -219,7 +225,7 @@ class IcebergTableStream(Stream):
             Closed window ``(window_start, window_start + window_size_hours]``.
             Bookmark advances by exactly ``window_size_hours`` per successful run.
         Tail: window would overshoot ``now``.
-            Open-ended filter ``updated_at > window_start``.
+            Open-ended filter ``updated_at >= window_start``.
             Bookmark advances to the max ``updated_at`` observed during the run.
 
         In both phases, the bookmark is only persisted by ``_finalize_state``
@@ -287,14 +293,14 @@ class IcebergTableStream(Stream):
             # ---- Tail phase: open-ended scan, running-max bookmark ----
             self._planned_bookmark = None
             self._max_observed = None
-            filter_expression = GreaterThan(
+            filter_expression = GreaterThanOrEqual(
                 self.replication_key, window_start.isoformat(),
             )
             self.logger.info(
-                "Iceberg tail scan [phase=tail]: %s < %s (running-max bookmark, "
+                "Iceberg tail scan [phase=tail]: %s >= %s (running-max bookmark, "
                 "candidate_end=%s would overshoot now=%s)",
-                window_start.isoformat(),
                 self.replication_key,
+                window_start.isoformat(),
                 candidate_end.isoformat(),
                 now.isoformat(),
             )

--- a/tap_iceberg/streams.py
+++ b/tap_iceberg/streams.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import pyarrow as pa
 from pyiceberg.expressions import AlwaysTrue, And, GreaterThan, LessThanOrEqual
+from pyiceberg.types import TimestamptzType
 from singer_sdk import Stream  # JSON Schema typing helpers
 
 from tap_iceberg.map_json import normalize_pyarrow_map_for_json
@@ -167,6 +168,26 @@ class IcebergTableStream(Stream):
         """Bounded by Iceberg row_filter for incremental windows, not utc_now."""
         return None
 
+    def _replication_column_is_tz_aware(self) -> bool:
+        """Return True iff the Iceberg replication column is ``timestamptz``.
+
+        PyIceberg's ``TimestampType`` (no zone) rejects ISO literals that carry an
+        offset (``ValueError: Zone offset provided, but not expected``), and
+        ``TimestamptzType`` requires an offset. We inspect the table schema so the
+        same tap works regardless of which shape the operator passes in
+        ``start-replication-key-value`` / state.
+        """
+        rk = self.replication_key
+        if not rk:
+            return False
+        try:
+            field = self._iceberg_table.schema().find_field(rk)
+        except Exception:
+            return False
+        if field is None:
+            return False
+        return isinstance(field.field_type, TimestamptzType)
+
     def get_records(self, context: dict | None = None) -> Iterable[dict]:
         """Yield records from a single closed time window of the Iceberg table.
 
@@ -197,8 +218,17 @@ class IcebergTableStream(Stream):
         window_start_str = state_bookmark or bootstrap_start
 
         window_start = datetime.fromisoformat(window_start_str)
-        if window_start.tzinfo is None:
-            window_start = window_start.replace(tzinfo=timezone.utc)
+        column_is_tz_aware = self._replication_column_is_tz_aware()
+        if column_is_tz_aware:
+            if window_start.tzinfo is None:
+                window_start = window_start.replace(tzinfo=timezone.utc)
+        else:
+            # PyIceberg's `TimestampType` rejects literals with a zone offset.
+            # Normalize aware → UTC then strip tzinfo so the column literal matches.
+            if window_start.tzinfo is not None:
+                window_start = window_start.astimezone(timezone.utc).replace(
+                    tzinfo=None,
+                )
         window_end = window_start + timedelta(hours=int(window_hours))
 
         self.logger.info(

--- a/tap_iceberg/tap.py
+++ b/tap_iceberg/tap.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
 from pyiceberg.catalog import load_catalog
 from singer_sdk import Tap
@@ -14,6 +14,31 @@ if TYPE_CHECKING:
     from pyiceberg.catalog import Catalog
 
     from tap_iceberg.streams import IcebergTableStream
+
+_REDACTED_CATALOG_DEBUG_KEYS = frozenset(
+    {
+        "client.access-key-id",
+        "client.secret-access-key",
+        "client.session-token",
+        "s3.access-key-id",
+        "s3.secret-access-key",
+        "s3.session-token",
+    },
+)
+
+
+def _catalog_properties_for_debug_log(props: Mapping[str, object]) -> dict[str, object]:
+    """Avoid dumping raw AWS keys when catalog_properties are logged at DEBUG."""
+
+    safe: dict[str, object] = {}
+    for key, val in props.items():
+        if key in _REDACTED_CATALOG_DEBUG_KEYS:
+            safe[key] = "<redacted>"
+        elif key == "botocore_session":
+            safe[key] = "<botocore.Session>"
+        else:
+            safe[key] = val
+    return safe
 
 
 class TapIceberg(Tap):
@@ -138,7 +163,7 @@ class TapIceberg(Tap):
 
         self.logger.debug(
             "Loading Iceberg catalog with properties: %s",
-            catalog_properties,
+            _catalog_properties_for_debug_log(catalog_properties),
         )
 
         return load_catalog(

--- a/tap_iceberg/tap.py
+++ b/tap_iceberg/tap.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
-from botocore.credentials import Credentials
 from pyiceberg.catalog import load_catalog
 from singer_sdk import Tap
 from singer_sdk import typing as th
 
-from tap_iceberg.utils import (
-    get_refreshable_botocore_session,
-)
+from tap_iceberg.aws_session import attach_catalog_aws_credentials
 
 if TYPE_CHECKING:
     from pyiceberg.catalog import Catalog
@@ -69,7 +65,16 @@ class TapIceberg(Tap):
             "client_iam_role_arn",
             th.StringType,
             required=False,
-            description="The ARN of the IAM role to use for accessing S3/Glue catalog",
+            description="Optional second-hop IAM role ARN (customer data role)",
+        ),
+        th.Property(
+            "customer_data_access_role_arn",
+            th.StringType,
+            required=False,
+            description=(
+                "Shaped intermediary IAM role ARN (first AssumeRole hop from "
+                "IRSA/pod identity); also readable from CUSTOMER_DATA_ACCESS_ROLE_ARN"
+            ),
         ),
         th.Property(
             "catalog_properties",
@@ -84,7 +89,6 @@ class TapIceberg(Tap):
         from tap_iceberg.streams import (
             IcebergTableStream,
         )
-        from pyiceberg.exceptions import NoSuchPropertyException
 
         catalog = self._get_catalog()
         discovered_streams = []
@@ -97,7 +101,9 @@ class TapIceberg(Tap):
                 except (KeyError, Exception) as e:
                     if "Parameters" in str(e) or "table_type" in str(e):
                         self.logger.debug(
-                            f"Skipping {table_id}: not a valid Iceberg table ({e})."
+                            "Skipping %s: not a valid Iceberg table (%s).",
+                            table_id,
+                            e,
                         )
                         continue
                     raise
@@ -112,68 +118,18 @@ class TapIceberg(Tap):
 
     def _get_catalog(self) -> Catalog:
         """Load and return the Iceberg catalog based on the configuration."""
-        catalog_properties = self.config.get("catalog_properties", {})
+        catalog_properties = dict(self.config.get("catalog_properties", {}))
         catalog_properties.update(
             {
                 "type": self.config["catalog_type"],
-            }
+            },
         )
 
-        # Export AWS credentials to the catalog properties, and standard AWS
-        # environment variables to override any system credentials.
-        client_access_key_id = self.config.get("client_access_key_id")
-        client_secret_access_key = self.config.get("client_secret_access_key")
-        client_session_token = self.config.get("client_session_token")
-        client_region = self.config.get("client_region")
-
-        if client_region:
-            catalog_properties["client.region"] = client_region
-            os.environ["AWS_DEFAULT_REGION"] = client_region
-
-        # If client IAM role ARN is provided, use provided credentials to assume
-        # the role and create a botocore session with the assumed role, using those
-        # refreshable credentials.
-        if self.config.get("client_iam_role_arn"):
-            role_session_name = "TapIceberg"
-            self.logger.info(
-                "Assuming role %s with session name %s.",
-                self.config["client_iam_role_arn"],
-                role_session_name,
-            )
-            if client_access_key_id:
-                os.environ["AWS_ACCESS_KEY_ID"] = client_access_key_id
-            if client_secret_access_key:
-                os.environ["AWS_SECRET_ACCESS_KEY"] = client_secret_access_key
-            if client_session_token:
-                os.environ["AWS_SESSION_TOKEN"] = client_session_token
-
-            base_credentials = None
-            if client_access_key_id and client_secret_access_key:
-                base_credentials = Credentials(
-                    access_key=client_access_key_id,
-                    secret_key=client_secret_access_key,
-                    token=client_session_token,
-                )
-            botocore_session = get_refreshable_botocore_session(
-                source_credentials=base_credentials,
-                assume_role_arn=self.config["client_iam_role_arn"],
-                role_session_name=role_session_name,
-            )
-            catalog_properties["botocore_session"] = botocore_session
-            catalog_properties["client.role-arn"] = self.config["client_iam_role_arn"]
-            catalog_properties["client.session-name"] = role_session_name
-        else:
-            if client_access_key_id:
-                catalog_properties["client.access-key-id"] = client_access_key_id
-                os.environ["AWS_ACCESS_KEY_ID"] = client_access_key_id
-            if client_secret_access_key:
-                catalog_properties["client.secret-access-key"] = (
-                    client_secret_access_key
-                )
-                os.environ["AWS_SECRET_ACCESS_KEY"] = client_secret_access_key
-            if client_session_token:
-                catalog_properties["client.session-token"] = client_session_token
-                os.environ["AWS_SESSION_TOKEN"] = client_session_token
+        attach_catalog_aws_credentials(
+            catalog_properties,
+            config=self.config,
+            logger=self.logger,
+        )
 
         self.logger.debug(
             "Loading Iceberg catalog with properties: %s",

--- a/tap_iceberg/tap.py
+++ b/tap_iceberg/tap.py
@@ -65,15 +65,20 @@ class TapIceberg(Tap):
             "client_iam_role_arn",
             th.StringType,
             required=False,
-            description="Optional second-hop IAM role ARN (customer data role)",
+            description=(
+                "Second-hop IAM role ARN (customer Glue/lake reader) after "
+                "customer_data_access_role_arn when using IRSA; trust must allow the "
+                "first-hop role (not necessarily the pod identity)"
+            ),
         ),
         th.Property(
             "customer_data_access_role_arn",
             th.StringType,
             required=False,
             description=(
-                "Shaped intermediary IAM role ARN (first AssumeRole hop from "
-                "IRSA/pod identity); also readable from CUSTOMER_DATA_ACCESS_ROLE_ARN"
+                "First AssumeRole hop from IRSA/pod identity (often "
+                "`CustomerS3DataAccessRole` in your ops account); also readable from env "
+                "TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN or CUSTOMER_DATA_ACCESS_ROLE_ARN"
             ),
         ),
         th.Property(

--- a/tap_iceberg/utils.py
+++ b/tap_iceberg/utils.py
@@ -1,58 +1,8 @@
 from __future__ import annotations
 
 import pyarrow as pa
-from boto3 import Session
-from botocore.credentials import (
-    AssumeRoleCredentialFetcher,
-    Credentials,
-    DeferredRefreshableCredentials,
-)
-from botocore.session import Session as BotoSession
 from pyarrow import DataType
 from singer_sdk import typing as th
-
-
-def get_refreshable_botocore_session(
-    source_credentials: Credentials | None,
-    assume_role_arn: str,
-    role_session_name: str | None = None,
-) -> BotoSession:
-    """Get a refreshable botocore session for assuming a role."""
-    if source_credentials is not None:
-        boto3_session = Session(
-            aws_access_key_id=source_credentials.access_key,
-            aws_secret_access_key=source_credentials.secret_key,
-            aws_session_token=source_credentials.token,
-        )
-        fetcher_source = source_credentials
-    else:
-        boto3_session = Session()
-        fetcher_source = boto3_session.get_credentials()
-        if fetcher_source is None:
-            msg = (
-                "No AWS credentials found to assume the IAM role. Configure "
-                "client_access_key_id and client_secret_access_key, or set up "
-                "default credentials (e.g. AWS_PROFILE, ~/.aws/credentials, "
-                "aws sso login)."
-            )
-            raise ValueError(msg)
-
-    extra_args = {}
-    if role_session_name:
-        extra_args["RoleSessionName"] = role_session_name
-    fetcher = AssumeRoleCredentialFetcher(
-        client_creator=boto3_session.client,
-        source_credentials=fetcher_source,
-        role_arn=assume_role_arn,
-        extra_args=extra_args,
-    )
-    refreshable_credentials = DeferredRefreshableCredentials(
-        method="assume-role",
-        refresh_using=fetcher.fetch_credentials,
-    )
-    botocore_session = BotoSession()
-    botocore_session._credentials = refreshable_credentials  # noqa: SLF001
-    return botocore_session
 
 
 def pyarrow_to_jsonschema_type(arrow_type: DataType) -> th.JSONTypeHelper:

--- a/tests/test_aws_session.py
+++ b/tests/test_aws_session.py
@@ -130,13 +130,16 @@ def test_second_get_frozen_triggers_second_assume_when_cache_bypassed() -> None:
                         getenv=lambda _k: None,
                     )
 
-    sess_obj = catalog["botocore_session"]
-    crs = sess_obj.get_credentials()
+                    sess_obj = catalog["botocore_session"]
+                    crs = sess_obj.get_credentials()
 
-    crs.get_frozen_credentials()
-    crs.get_frozen_credentials()
+                    crs.get_frozen_credentials()
+                    # Botocore skips a second STS round-trip while creds look fresh;
+                    # force advisory refresh to exercise _get_credentials again.
+                    crs._expiry_time = datetime.now(timezone.utc) - timedelta(minutes=1)
+                    crs.get_frozen_credentials()
 
-    assert calls["n"] >= 2
+                    assert calls["n"] >= 2
 
 
 def test_customer_data_arn_from_env_when_config_empty() -> None:

--- a/tests/test_aws_session.py
+++ b/tests/test_aws_session.py
@@ -188,3 +188,50 @@ def test_customer_data_arn_from_env_when_config_empty() -> None:
     assert RecordingAssume.captures == [
         "arn:aws:iam::777:role/EnvCustomerDataAccess",
     ]
+
+
+def test_customer_data_arn_env_tap_prefixed_wins_over_plain_env() -> None:
+    class RecordingAssume(AssumeRoleCredentialFetcher):
+        captures: ClassVar[list[str]] = []
+
+        def __init__(  # type: ignore[no-untyped-def]
+            self,
+            client_creator,
+            source_credentials,
+            role_arn,
+            extra_args=None,
+            **kwargs,
+        ):
+            RecordingAssume.captures.append(role_arn)
+            super().__init__(
+                client_creator,
+                source_credentials,
+                role_arn,
+                extra_args=extra_args,
+                **kwargs,
+            )
+
+    RecordingAssume.captures.clear()
+    canned = Credentials("IRSA-ID", "IRSA-SKEY")
+
+    def getenv(name: str) -> Optional[str]:
+        if name == "TAP_ICEBERG_CUSTOMER_DATA_ACCESS_ROLE_ARN":
+            return "arn:aws:iam::888:role/TapPrefixedHop"
+        if name == "CUSTOMER_DATA_ACCESS_ROLE_ARN":
+            return "arn:aws:iam::777:role/PlainEnvHop"
+        return None
+
+    with patch.object(Boto3Session, "get_credentials", lambda self: canned):
+        with patch.object(
+            aws_session,
+            "AssumeRoleCredentialFetcher",
+            RecordingAssume,
+        ):
+            attach_catalog_aws_credentials(
+                {},
+                config={},
+                logger=MagicMock(),
+                getenv=getenv,
+            )
+
+    assert RecordingAssume.captures[0] == "arn:aws:iam::888:role/TapPrefixedHop"

--- a/tests/test_aws_session.py
+++ b/tests/test_aws_session.py
@@ -62,7 +62,7 @@ def test_intermediary_then_customer_roles_order() -> None:
         ):
             with patch.object(
                 aws_session,
-                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                "_wire_refreshing_pyarrow_io",
                 MagicMock(),
             ):
                 attach_catalog_aws_credentials(
@@ -135,7 +135,13 @@ def test_second_get_frozen_triggers_second_assume_when_cache_bypassed() -> None:
                         getenv=lambda _k: None,
                     )
 
-                    assert catalog["s3.access-key-id"] == "TEMP1"
+                    assert (
+                        catalog["py-io-impl"]
+                        == "tap_iceberg.refreshing_pyarrow_io.RefreshingPyArrowFileIO"
+                    )
+                    assert isinstance(
+                        catalog["tap_iceberg.botocore_session_key"], str
+                    )
 
                     sess_obj = catalog["botocore_session"]
                     crs = sess_obj.get_credentials()
@@ -186,7 +192,7 @@ def test_customer_data_arn_from_env_when_config_empty() -> None:
         ):
             with patch.object(
                 aws_session,
-                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                "_wire_refreshing_pyarrow_io",
                 MagicMock(),
             ):
                 mode = attach_catalog_aws_credentials(
@@ -241,7 +247,7 @@ def test_customer_data_arn_env_tap_prefixed_wins_over_plain_env() -> None:
         ):
             with patch.object(
                 aws_session,
-                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                "_wire_refreshing_pyarrow_io",
                 MagicMock(),
             ):
                 attach_catalog_aws_credentials(

--- a/tests/test_aws_session.py
+++ b/tests/test_aws_session.py
@@ -1,0 +1,187 @@
+"""Tests for STS / IRSA credential resolution (``tap_iceberg.aws_session``)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import ClassVar, Optional
+from unittest.mock import MagicMock, patch
+
+from boto3 import Session as Boto3Session
+from botocore.credentials import AssumeRoleCredentialFetcher
+from botocore.credentials import CachedCredentialFetcher
+from botocore.credentials import Credentials
+
+from tap_iceberg import aws_session
+from tap_iceberg.aws_session import attach_catalog_aws_credentials
+
+
+def test_legacy_static_without_assume_writes_key_properties() -> None:
+    catalog: dict[str, object] = {}
+    attach_catalog_aws_credentials(
+        catalog,
+        config={
+            "client_access_key_id": "AKTEST",
+            "client_secret_access_key": "secret",
+        },
+        logger=MagicMock(),
+        getenv=lambda _k: None,
+    )
+    assert catalog["client.access-key-id"] == "AKTEST"
+    assert "botocore_session" not in catalog
+
+
+def test_intermediary_then_customer_roles_order() -> None:
+    class RecordingAssume(AssumeRoleCredentialFetcher):
+        captures: ClassVar[list[str]] = []
+
+        def __init__(  # type: ignore[no-untyped-def]
+            self,
+            client_creator,
+            source_credentials,
+            role_arn,
+            extra_args=None,
+            **kwargs,
+        ):
+            RecordingAssume.captures.append(role_arn)
+            super().__init__(
+                client_creator,
+                source_credentials,
+                role_arn,
+                extra_args=extra_args,
+                **kwargs,
+            )
+
+    RecordingAssume.captures.clear()
+    canned = Credentials("IRSA-ID", "IRSA-SKEY")
+
+    with patch.object(Boto3Session, "get_credentials", lambda self: canned):
+        with patch.object(
+            aws_session,
+            "AssumeRoleCredentialFetcher",
+            RecordingAssume,
+        ):
+            attach_catalog_aws_credentials(
+                {},
+                config={
+                    "customer_data_access_role_arn": (
+                        "arn:aws:iam::111111111111:role/ShapedCustomerData"
+                    ),
+                    "client_iam_role_arn": (
+                        "arn:aws:iam::222222222222:role/CustomerLakeRead"
+                    ),
+                },
+                logger=MagicMock(),
+                getenv=lambda _k: None,
+            )
+
+    assert RecordingAssume.captures == [
+        "arn:aws:iam::111111111111:role/ShapedCustomerData",
+        "arn:aws:iam::222222222222:role/CustomerLakeRead",
+    ]
+
+
+def test_second_get_frozen_triggers_second_assume_when_cache_bypassed() -> None:
+    canned = Credentials("IRSA-ID", "IRSA-SKEY")
+    calls = {"n": 0}
+
+    def _fake_assume_identity(n: int) -> dict[str, object]:
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        return {
+            "Credentials": {
+                "AccessKeyId": f"TEMP{n}",
+                "SecretAccessKey": "secret",
+                "SessionToken": f"tok-{n}",
+                "Expiration": expiry,
+            },
+            "AssumedRoleUser": {
+                "Arn": f"arn:aws:sts::1:assumed-role/r{n}/sess",
+            },
+        }
+
+    def tracked_get(inner_self: AssumeRoleCredentialFetcher) -> dict[str, object]:
+        calls["n"] += 1
+        return _fake_assume_identity(calls["n"])
+
+    with patch.object(Boto3Session, "get_credentials", lambda self: canned):
+        with patch.object(
+            AssumeRoleCredentialFetcher,
+            "_get_credentials",
+            tracked_get,
+        ):
+            with patch.object(
+                CachedCredentialFetcher,
+                "_load_from_cache",
+                return_value=None,
+            ):
+                with patch.object(
+                    CachedCredentialFetcher,
+                    "_write_to_cache",
+                    lambda _self, _resp: None,
+                ):
+                    catalog: dict[str, object] = {}
+                    attach_catalog_aws_credentials(
+                        catalog,
+                        config={
+                            "client_iam_role_arn": (
+                                "arn:aws:iam::999:role/AssumeMe"
+                            ),
+                        },
+                        logger=MagicMock(),
+                        getenv=lambda _k: None,
+                    )
+
+    sess_obj = catalog["botocore_session"]
+    crs = sess_obj.get_credentials()
+
+    crs.get_frozen_credentials()
+    crs.get_frozen_credentials()
+
+    assert calls["n"] >= 2
+
+
+def test_customer_data_arn_from_env_when_config_empty() -> None:
+    class RecordingAssume(AssumeRoleCredentialFetcher):
+        captures: ClassVar[list[str]] = []
+
+        def __init__(  # type: ignore[no-untyped-def]
+            self,
+            client_creator,
+            source_credentials,
+            role_arn,
+            extra_args=None,
+            **kwargs,
+        ):
+            RecordingAssume.captures.append(role_arn)
+            super().__init__(
+                client_creator,
+                source_credentials,
+                role_arn,
+                extra_args=extra_args,
+                **kwargs,
+            )
+
+    RecordingAssume.captures.clear()
+    canned = Credentials("IRSA-ID", "IRSA-SKEY")
+
+    def getenv(name: str) -> Optional[str]:
+        if name == "CUSTOMER_DATA_ACCESS_ROLE_ARN":
+            return "arn:aws:iam::777:role/EnvCustomerDataAccess"
+        return None
+
+    with patch.object(Boto3Session, "get_credentials", lambda self: canned):
+        with patch.object(
+            aws_session,
+            "AssumeRoleCredentialFetcher",
+            RecordingAssume,
+        ):
+            mode = attach_catalog_aws_credentials(
+                {},
+                config={},
+                logger=MagicMock(),
+                getenv=getenv,
+            )
+
+    assert mode == aws_session.CredentialModeRefreshableIrsaCustomerDataAccessChain
+    assert RecordingAssume.captures == [
+        "arn:aws:iam::777:role/EnvCustomerDataAccess",
+    ]

--- a/tests/test_aws_session.py
+++ b/tests/test_aws_session.py
@@ -60,19 +60,24 @@ def test_intermediary_then_customer_roles_order() -> None:
             "AssumeRoleCredentialFetcher",
             RecordingAssume,
         ):
-            attach_catalog_aws_credentials(
-                {},
-                config={
-                    "customer_data_access_role_arn": (
-                        "arn:aws:iam::111111111111:role/ShapedCustomerData"
-                    ),
-                    "client_iam_role_arn": (
-                        "arn:aws:iam::222222222222:role/CustomerLakeRead"
-                    ),
-                },
-                logger=MagicMock(),
-                getenv=lambda _k: None,
-            )
+            with patch.object(
+                aws_session,
+                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                MagicMock(),
+            ):
+                attach_catalog_aws_credentials(
+                    {},
+                    config={
+                        "customer_data_access_role_arn": (
+                            "arn:aws:iam::111111111111:role/ShapedCustomerData"
+                        ),
+                        "client_iam_role_arn": (
+                            "arn:aws:iam::222222222222:role/CustomerLakeRead"
+                        ),
+                    },
+                    logger=MagicMock(),
+                    getenv=lambda _k: None,
+                )
 
     assert RecordingAssume.captures == [
         "arn:aws:iam::111111111111:role/ShapedCustomerData",
@@ -130,6 +135,8 @@ def test_second_get_frozen_triggers_second_assume_when_cache_bypassed() -> None:
                         getenv=lambda _k: None,
                     )
 
+                    assert catalog["s3.access-key-id"] == "TEMP1"
+
                     sess_obj = catalog["botocore_session"]
                     crs = sess_obj.get_credentials()
 
@@ -177,12 +184,17 @@ def test_customer_data_arn_from_env_when_config_empty() -> None:
             "AssumeRoleCredentialFetcher",
             RecordingAssume,
         ):
-            mode = attach_catalog_aws_credentials(
-                {},
-                config={},
-                logger=MagicMock(),
-                getenv=getenv,
-            )
+            with patch.object(
+                aws_session,
+                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                MagicMock(),
+            ):
+                mode = attach_catalog_aws_credentials(
+                    {},
+                    config={},
+                    logger=MagicMock(),
+                    getenv=getenv,
+                )
 
     assert mode == aws_session.CredentialModeRefreshableIrsaCustomerDataAccessChain
     assert RecordingAssume.captures == [
@@ -227,11 +239,16 @@ def test_customer_data_arn_env_tap_prefixed_wins_over_plain_env() -> None:
             "AssumeRoleCredentialFetcher",
             RecordingAssume,
         ):
-            attach_catalog_aws_credentials(
-                {},
-                config={},
-                logger=MagicMock(),
-                getenv=getenv,
-            )
+            with patch.object(
+                aws_session,
+                "_inject_pyiceberg_s3_credentials_from_botocore_session",
+                MagicMock(),
+            ):
+                attach_catalog_aws_credentials(
+                    {},
+                    config={},
+                    logger=MagicMock(),
+                    getenv=getenv,
+                )
 
     assert RecordingAssume.captures[0] == "arn:aws:iam::888:role/TapPrefixedHop"

--- a/tests/test_refreshing_pyarrow_io.py
+++ b/tests/test_refreshing_pyarrow_io.py
@@ -1,0 +1,120 @@
+"""Tests for ``tap_iceberg.refreshing_pyarrow_io.RefreshingPyArrowFileIO``."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+from unittest.mock import patch
+
+from tap_iceberg import refreshing_pyarrow_io
+
+
+class _FrozenCreds:
+    def __init__(self, access_key: str, secret_key: str, token: Optional[str]) -> None:
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.token = token
+
+
+class _StubRefreshableCredentials:
+    """Mimic the bits of ``botocore.credentials.RefreshableCredentials`` we use."""
+
+    def __init__(
+        self,
+        *,
+        access_key: str,
+        secret_key: str,
+        token: Optional[str],
+        expiry_time: Optional[float],
+    ) -> None:
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.token = token
+        self._expiry_time: Optional[float] = expiry_time
+
+    def get_frozen_credentials(self) -> _FrozenCreds:
+        return _FrozenCreds(self.access_key, self.secret_key, self.token)
+
+
+class _StubBotoSession:
+    def __init__(self, credentials: _StubRefreshableCredentials) -> None:
+        self.credentials = credentials
+
+    def get_credentials(self) -> _StubRefreshableCredentials:
+        return self.credentials
+
+
+def _capture_s3_kwargs() -> tuple[list[dict[str, Any]], Any]:
+    calls: list[dict[str, Any]] = []
+
+    class _RecordingS3FileSystem:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+            self.kwargs = kwargs
+
+    return calls, _RecordingS3FileSystem
+
+
+def test_refreshing_pyarrow_io_rebuilds_after_simulated_sts_refresh() -> None:
+    creds = _StubRefreshableCredentials(
+        access_key="AK1",
+        secret_key="secret",
+        token="tok1",
+        expiry_time=time.time() + 3600,
+    )
+    boto_session = _StubBotoSession(creds)
+    key = refreshing_pyarrow_io.register_botocore_session(boto_session)
+
+    calls, recording_cls = _capture_s3_kwargs()
+
+    with patch.object(refreshing_pyarrow_io, "S3FileSystem", recording_cls):
+        io = refreshing_pyarrow_io.RefreshingPyArrowFileIO(
+            properties={
+                refreshing_pyarrow_io.SESSION_KEY_PROPERTY: key,
+                "s3.region": "us-east-1",
+            },
+        )
+
+        fs1 = io.fs_by_scheme("s3", "bucket")
+        fs2 = io.fs_by_scheme("s3", "bucket")
+        assert fs1 is fs2  # cache hit while creds remain fresh
+
+        creds.access_key = "AK2"
+        creds.token = "tok2"
+        creds._expiry_time = time.time() + 7200
+
+        fs3 = io.fs_by_scheme("s3", "bucket")
+        assert fs3 is not fs1  # rebuilt after simulated STS refresh
+
+    assert [c["access_key"] for c in calls] == ["AK1", "AK2"]
+    assert calls[0]["region"] == "us-east-1"
+    assert calls[1]["session_token"] == "tok2"
+
+
+def test_refreshing_pyarrow_io_rebuilds_when_inside_refresh_window() -> None:
+    creds = _StubRefreshableCredentials(
+        access_key="AK1",
+        secret_key="secret",
+        token="tok1",
+        expiry_time=time.time() + 3600,
+    )
+    boto_session = _StubBotoSession(creds)
+    key = refreshing_pyarrow_io.register_botocore_session(boto_session)
+
+    calls, recording_cls = _capture_s3_kwargs()
+
+    with patch.object(refreshing_pyarrow_io, "S3FileSystem", recording_cls):
+        io = refreshing_pyarrow_io.RefreshingPyArrowFileIO(
+            properties={refreshing_pyarrow_io.SESSION_KEY_PROPERTY: key},
+        )
+        first = io.fs_by_scheme("s3", "bucket")
+        creds._expiry_time = time.time() + 60  # inside 5-min refresh window
+        second = io.fs_by_scheme("s3", "bucket")
+
+    assert first is not second
+    assert len(calls) == 2
+
+
+def test_refreshing_pyarrow_io_falls_back_when_no_session_registered() -> None:
+    io = refreshing_pyarrow_io.RefreshingPyArrowFileIO(properties={})
+    assert io._session_key is None

--- a/tests/test_windowed_incremental.py
+++ b/tests/test_windowed_incremental.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -49,14 +50,79 @@ def iceberg_table_mock(mock_batch_reader):
     return tbl
 
 
-def test_incremental_raises_when_window_metadata_missing(mock_tap, iceberg_table_mock):
+def test_incremental_raises_when_window_metadata_missing(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
     stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
     stream.forced_replication_method = "INCREMENTAL"
     stream.replication_key = "updated_at"
-    stream._get_stream_metadata_value = MagicMock(return_value=None)  # type: ignore[method-assign]
 
     with pytest.raises(ValueError, match="window-size-hours"):
         list(stream.get_records())
+
+
+def test_incremental_reads_window_fields_from_env_wildcard(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 6,
+                    "start-replication-key-value": "2024-01-01T00:00:00+00:00",
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    assert stream._planned_window_end == "2024-01-01T06:00:00+00:00"
+
+
+def test_stream_specific_metadata_overrides_wildcard(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 6,
+                    "start-replication-key-value": "2024-01-01T00:00:00+00:00",
+                },
+                "ns-tbl": {"window-size-hours": 168},
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    assert stream._planned_window_end == "2024-01-08T00:00:00+00:00"
 
 
 def test_incremental_planned_bookmark_is_window_right_edge(mock_tap, iceberg_table_mock):

--- a/tests/test_windowed_incremental.py
+++ b/tests/test_windowed_incremental.py
@@ -1,0 +1,97 @@
+"""Tests for time-windowed incremental sync (Magnus TAP_ICEBERG__METADATA)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pyiceberg")
+
+import pyarrow as pa
+
+from tap_iceberg.streams import IcebergTableStream
+
+
+def _minimal_arrow_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("updated_at", pa.timestamp("ms", tz="UTC")),
+        ]
+    )
+
+
+@pytest.fixture
+def mock_tap():
+    tap = MagicMock()
+    tap.name = "tap-iceberg"
+    tap._tap_state = {"bookmarks": {}}
+    tap.config = {}
+    return tap
+
+
+@pytest.fixture
+def mock_batch_reader():
+    """Empty Arrow batch iterable."""
+    reader = MagicMock()
+    reader.__iter__ = lambda _: iter([])
+    return reader
+
+
+@pytest.fixture
+def iceberg_table_mock(mock_batch_reader):
+    tbl = MagicMock()
+    tbl.schema.return_value.as_arrow.return_value = _minimal_arrow_schema()
+    scan_mock = MagicMock()
+    scan_mock.to_arrow_batch_reader.return_value = mock_batch_reader
+    tbl.scan.return_value = scan_mock
+    return tbl
+
+
+def test_incremental_raises_when_window_metadata_missing(mock_tap, iceberg_table_mock):
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream._get_stream_metadata_value = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="window-size-hours"):
+        list(stream.get_records())
+
+
+def test_incremental_planned_bookmark_is_window_right_edge(mock_tap, iceberg_table_mock):
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+
+    meta = {
+        "window-size-hours": 6,
+        "start-replication-key-value": "2024-01-01T00:00:00+00:00",
+    }
+    stream._get_stream_metadata_value = (  # type: ignore[method-assign]
+        lambda key, default=None: meta.get(key, default)
+    )
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    iceberg_table_mock.scan.assert_called_once()
+    row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
+    assert type(row_filter).__name__ == "And"
+    assert stream._planned_window_end == "2024-01-01T06:00:00+00:00"
+
+
+def test_full_table_uses_always_true_scan_and_clears_planned(mock_tap, iceberg_table_mock):
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = None
+    stream.replication_key = None
+
+    stream._planned_window_end = "should-not-stick"
+    list(stream.get_records())
+
+    iceberg_table_mock.scan.assert_called_once()
+    row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
+    assert type(row_filter).__name__ == "AlwaysTrue"
+    assert stream._planned_window_end is None

--- a/tests/test_windowed_incremental.py
+++ b/tests/test_windowed_incremental.py
@@ -10,6 +10,11 @@ import pytest
 pytest.importorskip("pyiceberg")
 
 import pyarrow as pa
+from pyiceberg.types import (
+    NestedField,
+    TimestampType,
+    TimestamptzType,
+)
 
 from tap_iceberg.streams import IcebergTableStream
 
@@ -40,14 +45,44 @@ def mock_batch_reader():
     return reader
 
 
-@pytest.fixture
-def iceberg_table_mock(mock_batch_reader):
+def _build_iceberg_table_mock(
+    batch_reader: MagicMock,
+    *,
+    replication_column_type,
+) -> MagicMock:
     tbl = MagicMock()
-    tbl.schema.return_value.as_arrow.return_value = _minimal_arrow_schema()
+    schema_obj = MagicMock()
+    schema_obj.as_arrow.return_value = _minimal_arrow_schema()
+    rk_field = NestedField(
+        field_id=2,
+        name="updated_at",
+        field_type=replication_column_type,
+        required=False,
+    )
+    schema_obj.find_field.return_value = rk_field
+    tbl.schema.return_value = schema_obj
     scan_mock = MagicMock()
-    scan_mock.to_arrow_batch_reader.return_value = mock_batch_reader
+    scan_mock.to_arrow_batch_reader.return_value = batch_reader
     tbl.scan.return_value = scan_mock
     return tbl
+
+
+@pytest.fixture
+def iceberg_table_mock(mock_batch_reader):
+    """Default fixture: replication column is `timestamptz` (aware)."""
+    return _build_iceberg_table_mock(
+        mock_batch_reader,
+        replication_column_type=TimestamptzType(),
+    )
+
+
+@pytest.fixture
+def iceberg_table_mock_naive(mock_batch_reader):
+    """Replication column is `timestamp` (no zone)."""
+    return _build_iceberg_table_mock(
+        mock_batch_reader,
+        replication_column_type=TimestampType(),
+    )
 
 
 def test_incremental_raises_when_window_metadata_missing(
@@ -147,6 +182,68 @@ def test_incremental_planned_bookmark_is_window_right_edge(mock_tap, iceberg_tab
     row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
     assert type(row_filter).__name__ == "And"
     assert stream._planned_window_end == "2024-01-01T06:00:00+00:00"
+
+
+def test_naive_column_strips_tz_offset_from_window_literals(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock_naive,
+):
+    """Operator passes ``+00:00`` but the Iceberg column is plain ``timestamp``."""
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 6,
+                    "start-replication-key-value": "2026-01-01T00:00:00+00:00",
+                },
+            },
+        ),
+    )
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock_naive)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    assert stream._planned_window_end == "2026-01-01T06:00:00"
+    row_filter = iceberg_table_mock_naive.scan.call_args.kwargs["row_filter"]
+    assert type(row_filter).__name__ == "And"
+
+
+def test_tz_aware_column_adds_utc_offset_when_input_is_naive(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    """Operator passes naive ISO but the column is ``timestamptz`` — assume UTC."""
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 6,
+                    "start-replication-key-value": "2026-01-01T00:00:00",
+                },
+            },
+        ),
+    )
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    assert stream._planned_window_end == "2026-01-01T06:00:00+00:00"
 
 
 def test_full_table_uses_always_true_scan_and_clears_planned(mock_tap, iceberg_table_mock):

--- a/tests/test_windowed_incremental.py
+++ b/tests/test_windowed_incremental.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -126,7 +127,8 @@ def test_incremental_reads_window_fields_from_env_wildcard(
 
     list(stream.get_records())
 
-    assert stream._planned_window_end == "2024-01-01T06:00:00+00:00"
+    assert stream._planned_bookmark == "2024-01-01T06:00:00+00:00"
+    assert stream._max_observed is None
 
 
 def test_stream_specific_metadata_overrides_wildcard(
@@ -157,7 +159,7 @@ def test_stream_specific_metadata_overrides_wildcard(
 
     list(stream.get_records())
 
-    assert stream._planned_window_end == "2024-01-08T00:00:00+00:00"
+    assert stream._planned_bookmark == "2024-01-08T00:00:00+00:00"
 
 
 def test_incremental_planned_bookmark_is_window_right_edge(mock_tap, iceberg_table_mock):
@@ -181,7 +183,7 @@ def test_incremental_planned_bookmark_is_window_right_edge(mock_tap, iceberg_tab
     iceberg_table_mock.scan.assert_called_once()
     row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
     assert type(row_filter).__name__ == "And"
-    assert stream._planned_window_end == "2024-01-01T06:00:00+00:00"
+    assert stream._planned_bookmark == "2024-01-01T06:00:00+00:00"
 
 
 def test_naive_column_strips_tz_offset_from_window_literals(
@@ -211,7 +213,7 @@ def test_naive_column_strips_tz_offset_from_window_literals(
 
     list(stream.get_records())
 
-    assert stream._planned_window_end == "2026-01-01T06:00:00"
+    assert stream._planned_bookmark == "2026-01-01T06:00:00"
     row_filter = iceberg_table_mock_naive.scan.call_args.kwargs["row_filter"]
     assert type(row_filter).__name__ == "And"
 
@@ -243,7 +245,7 @@ def test_tz_aware_column_adds_utc_offset_when_input_is_naive(
 
     list(stream.get_records())
 
-    assert stream._planned_window_end == "2026-01-01T06:00:00+00:00"
+    assert stream._planned_bookmark == "2026-01-01T06:00:00+00:00"
 
 
 def test_full_table_uses_always_true_scan_and_clears_planned(mock_tap, iceberg_table_mock):
@@ -251,10 +253,224 @@ def test_full_table_uses_always_true_scan_and_clears_planned(mock_tap, iceberg_t
     stream.forced_replication_method = None
     stream.replication_key = None
 
-    stream._planned_window_end = "should-not-stick"
+    stream._planned_bookmark = "should-not-stick"
+    stream._max_observed = "should-not-stick"
     list(stream.get_records())
 
     iceberg_table_mock.scan.assert_called_once()
     row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
     assert type(row_filter).__name__ == "AlwaysTrue"
-    assert stream._planned_window_end is None
+    assert stream._planned_bookmark is None
+    assert stream._max_observed is None
+
+
+# -- Tail-phase --------------------------------------------------------------
+
+
+def test_tail_phase_uses_open_ended_filter_and_running_max_bookmark(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    """When ``window_start + window_hours > now`` we switch to an open-ended
+    scan and the bookmark is the max replication_key value yielded."""
+    # window_start = now - 1h, window-size = 24h -> candidate_end is in the
+    # future, forcing tail phase.
+    start_dt = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+        microsecond=0,
+    )
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 24,
+                    "start-replication-key-value": start_dt.isoformat(),
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    # Three records, intentionally out of order, so we exercise the running-max
+    # comparison rather than relying on iteration order.
+    rk_mid = start_dt + timedelta(minutes=15)
+    rk_max = start_dt + timedelta(minutes=45)
+    rk_min = start_dt + timedelta(minutes=5)
+    stream._scan_and_yield_rows = lambda _filter: iter(  # type: ignore[method-assign]
+        [
+            {"id": 1, "updated_at": rk_mid},
+            {"id": 2, "updated_at": rk_max},
+            {"id": 3, "updated_at": rk_min},
+        ],
+    )
+
+    list(stream.get_records())
+
+    assert stream._planned_bookmark is None
+    assert stream._max_observed == rk_max
+
+
+def test_tail_phase_filter_is_open_ended_greater_than(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    start_dt = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+        microsecond=0,
+    )
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 24,
+                    "start-replication-key-value": start_dt.isoformat(),
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+
+    iceberg_table_mock.scan.assert_called_once()
+    row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
+    assert type(row_filter).__name__ == "GreaterThan"
+    assert stream._planned_bookmark is None
+
+
+def test_finalize_state_writes_planned_bookmark_for_backfill(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    """After a backfill run, ``_finalize_state`` should write the predetermined
+    window end to ``replication_key_value`` and leave no progress markers."""
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 6,
+                    "start-replication-key-value": "2024-01-01T00:00:00+00:00",
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+    final_state: dict = {}
+    stream._finalize_state(final_state)
+
+    assert final_state == {
+        "replication_key": "updated_at",
+        "replication_key_value": "2024-01-01T06:00:00+00:00",
+    }
+
+
+def test_finalize_state_promotes_max_observed_for_tail(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    start_dt = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+        microsecond=0,
+    )
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 24,
+                    "start-replication-key-value": start_dt.isoformat(),
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    rk_max = start_dt + timedelta(minutes=42)
+    stream._scan_and_yield_rows = lambda _filter: iter(  # type: ignore[method-assign]
+        [{"id": 1, "updated_at": rk_max}],
+    )
+
+    list(stream.get_records())
+    final_state: dict = {}
+    stream._finalize_state(final_state)
+
+    assert final_state["replication_key"] == "updated_at"
+    assert final_state["replication_key_value"] == rk_max.isoformat()
+
+
+def test_finalize_state_noop_when_no_records_in_tail_phase(
+    monkeypatch,
+    mock_tap,
+    iceberg_table_mock,
+):
+    """Tail run with zero records: ``_max_observed`` stays None, no bookmark
+    is written (the previous bookmark in Meltano Postgres is preserved)."""
+    start_dt = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+        microsecond=0,
+    )
+    monkeypatch.delenv("TAP_ICEBERG__METADATA", raising=False)
+    monkeypatch.setenv(
+        "TAP_ICEBERG__METADATA",
+        json.dumps(
+            {
+                "*": {
+                    "window-size-hours": 24,
+                    "start-replication-key-value": start_dt.isoformat(),
+                },
+            },
+        ),
+    )
+
+    stream = IcebergTableStream(mock_tap, "ns-tbl", iceberg_table_mock)
+    stream.forced_replication_method = "INCREMENTAL"
+    stream.replication_key = "updated_at"
+    stream.get_starting_replication_key_value = MagicMock(  # type: ignore[method-assign]
+        return_value=None,
+    )
+
+    list(stream.get_records())
+    final_state: dict = {}
+    stream._finalize_state(final_state)
+
+    assert "replication_key_value" not in final_state
+
+
+def test_check_sorted_disabled():
+    """Singer SDK must not raise InvalidStreamSortException on tail scans."""
+    assert IcebergTableStream.check_sorted.fget(  # type: ignore[union-attr]
+        MagicMock(spec=IcebergTableStream),
+    ) is False

--- a/tests/test_windowed_incremental.py
+++ b/tests/test_windowed_incremental.py
@@ -350,7 +350,7 @@ def test_tail_phase_filter_is_open_ended_greater_than(
 
     iceberg_table_mock.scan.assert_called_once()
     row_filter = iceberg_table_mock.scan.call_args.kwargs["row_filter"]
-    assert type(row_filter).__name__ == "GreaterThan"
+    assert type(row_filter).__name__ == "GreaterThanOrEqual"
     assert stream._planned_bookmark is None
 
 


### PR DESCRIPTION
## What we fixed

1. **Long Iceberg syncs failing on S3** — After ~1 hour, **temporary AWS credentials rotated**, but **PyArrow’s `S3FileSystem` kept old key/session strings**, so reads broke even though Glue/catalog calls could still work.

2. **Fragile / incomplete AWS catalog setup** — Credential wiring for **IRSA + chained `AssumeRole`** wasn’t centralized or robust enough for real Glue deployments.

3. **Incremental sync skipping “live” data** — **Fixed-size windows only**, with bookmark always **`start + window hours`**, could move the bookmark **past now** so **new rows never matched** the next filter.

4. **Magnus metadata ignored for windows** — **`window-size-hours`** / **`start-replication-key-value`** in **`TAP_ICEBERG__METADATA`** weren’t visible on Singer’s parsed catalog metadata, so the tap couldn’t read them from **`metadata`** alone.

5. **Timestamp filter crashes** — ISO strings **with offsets** vs Iceberg **`timestamp` (no TZ)** caused PyIceberg errors like **zone offset not expected**.

---

## How we fixed it

1. **`RefreshingPyArrowFileIO`** — Rebuilds **`S3FileSystem`** before creds expire, tied to the same refreshable **botocore** session used for the catalog.

2. **`tap_iceberg/aws_session.py`** — Single place that attaches **refreshable** credentials (legacy keys, IRSA, optional **two-hop** assume-role) into **`catalog_properties`** before **`load_catalog`**; tap logs redact secrets.

3. **Two-phase incremental in `streams.py`** — **Backfill**: closed window while **`start + W ≤ now`**, bookmark **`start + W`**. **Tail**: when that window would go past **now**, scan **`rk ≥ start`**, bookmark **`max(rk)`** after a **full** successful run; **`_finalize_state`** only.

4. **Parse `TAP_ICEBERG__METADATA` from the environment** — Merge **`"*"`** + per-stream overrides; cache safely on the tap (**`__dict__`** check so **`MagicMock`** tests behave).

5. **Schema-aware timestamps** — **`timestamptz`** vs **`timestamp`**: normalize bookmark/filter literals so operators can pass naive or offset ISO strings without blowing up filters.

6. **Tests** added for incremental phases, AWS session paths, and refreshing IO.